### PR TITLE
fix(query): query refresh on defineQuery output composable call

### DIFF
--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -12,10 +12,6 @@
         <RouterLink to="/contacts">
           Contacts
         </RouterLink>
-        |
-        <RouterLink to="/ecom">
-          T-shirts
-        </RouterLink>
       </nav>
     </div>
   </header>

--- a/playground/src/App.vue
+++ b/playground/src/App.vue
@@ -12,6 +12,10 @@
         <RouterLink to="/contacts">
           Contacts
         </RouterLink>
+        |
+        <RouterLink to="/ecom">
+          T-shirts
+        </RouterLink>
       </nav>
     </div>
   </header>

--- a/playground/src/composables/contacts.ts
+++ b/playground/src/composables/contacts.ts
@@ -2,12 +2,12 @@ import { defineQuery, useQuery } from '@pinia/colada'
 import { useRouteQuery } from '@vueuse/router'
 import { searchContacts } from '@/api/contacts'
 
-export const useContacts = defineQuery(() => {
+export const useContactSearch = defineQuery(() => {
   const searchText = useRouteQuery('search', '', { mode: 'push' })
   const { ...query } = useQuery({
     key: () => ['contacts-search', { searchText: searchText.value }],
     query: ({ signal }) => searchContacts(searchText.value, {}, { signal }),
-    gcTime: 0,
+    staleTime: 0,
   })
   return { ...query, searchText }
 })

--- a/playground/src/composables/contacts.ts
+++ b/playground/src/composables/contacts.ts
@@ -1,0 +1,13 @@
+import { defineQuery, useQuery } from '@pinia/colada'
+import { useRouteQuery } from '@vueuse/router'
+import { searchContacts } from '@/api/contacts'
+
+export const useContacts = defineQuery(() => {
+  const searchText = useRouteQuery('search', '', { mode: 'push' })
+  const { ...query } = useQuery({
+    key: () => ['contacts-search', { searchText: searchText.value }],
+    query: ({ signal }) => searchContacts(searchText.value, {}, { signal }),
+    gcTime: 0,
+  })
+  return { ...query, searchText }
+})

--- a/playground/src/pages/contacts.vue
+++ b/playground/src/pages/contacts.vue
@@ -1,14 +1,10 @@
 <script lang="ts" setup>
 import { useRouteQuery } from '@vueuse/router'
-import { useQuery } from '@pinia/colada'
-import { searchContacts } from '@/api/contacts'
+import { useContacts } from '@/composables/contacts'
 
 const searchText = useRouteQuery('search', '', { mode: 'push' })
 
-const { data: searchResult, status } = useQuery({
-  key: () => ['contacts-search', { searchText: searchText.value }],
-  query: ({ signal }) => searchContacts(searchText.value, {}, { signal }),
-})
+const { data: searchResult, status } = useContacts()
 
 // TODO: tip in tests if they are reading data, error or other as they are computed properties, on the server they won't
 // update so they will keep their initial undefined value

--- a/playground/src/pages/contacts.vue
+++ b/playground/src/pages/contacts.vue
@@ -1,10 +1,7 @@
 <script lang="ts" setup>
-import { useRouteQuery } from '@vueuse/router'
-import { useContacts } from '@/composables/contacts'
+import { useContactSearch } from '@/composables/contacts'
 
-const searchText = useRouteQuery('search', '', { mode: 'push' })
-
-const { data: searchResult, status } = useContacts()
+const { data: searchResult, status, searchText } = useContactSearch()
 
 // TODO: tip in tests if they are reading data, error or other as they are computed properties, on the server they won't
 // update so they will keep their initial undefined value

--- a/src/define-query.spec.ts
+++ b/src/define-query.spec.ts
@@ -1,18 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { enableAutoUnmount, mount } from '@vue/test-utils'
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
-import { ref } from 'vue'
+import type { App } from 'vue'
+import { createApp, defineComponent, ref } from 'vue'
 import { QueryPlugin } from './query-plugin'
 import { defineQuery } from './define-query'
 import { useQuery } from './use-query'
 
 describe('defineQuery', () => {
-    beforeEach(() => {
-      vi.useFakeTimers()
-    })
-    afterEach(() => {
-      vi.restoreAllMocks()
-    })
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
   enableAutoUnmount(afterEach)
 
@@ -74,5 +75,225 @@ describe('defineQuery', () => {
     expect(todoList).toBe(returnedValues.todoList)
     expect(todoFilter).toBe(useTodoList().todoFilter)
     expect(todoFilter).toBe(returnedValues.todoFilter)
+  })
+
+  describe('refetchOnMount', () => {
+    it('refreshes the query if mounted in a new component', async () => {
+      const spy = vi.fn(async () => {
+        return 'todos'
+      })
+      const useTodoList = defineQuery({
+        key: ['todos'],
+        query: spy,
+        refetchOnMount: true,
+        staleTime: 100,
+      })
+      let returnedValues!: ReturnType<typeof useTodoList>
+
+      const pinia = createPinia()
+      const Component = defineComponent({
+        setup() {
+          returnedValues = useTodoList()
+          return {}
+        },
+        template: `<div></div>`,
+      })
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      await flushPromises()
+
+      const { data, status } = returnedValues
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(status.value).toBe('success')
+      expect(data.value).toEqual('todos')
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      // still called only once
+      expect(spy).toHaveBeenCalledTimes(1)
+      // no ongoing call
+      expect(status.value).toBe('success')
+      expect(data.value).toEqual('todos')
+      await flushPromises()
+      expect(status.value).toBe('success')
+
+      vi.advanceTimersByTime(101)
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      // it should be loading
+      expect(status.value).toBe('loading')
+      expect(data.value).toEqual('todos')
+      await flushPromises()
+
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('refetches if refetchOnMount is always', async () => {
+      const spy = vi.fn(async () => {
+        return 'todos'
+      })
+      const useTodoList = defineQuery({
+        key: ['todos'],
+        query: spy,
+        refetchOnMount: 'always',
+        staleTime: 100,
+      })
+      let returnedValues!: ReturnType<typeof useTodoList>
+
+      const pinia = createPinia()
+      const Component = defineComponent({
+        setup() {
+          returnedValues = useTodoList()
+          return {}
+        },
+        template: `<div></div>`,
+      })
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      await flushPromises()
+
+      const { data, status } = returnedValues
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(status.value).toBe('success')
+      expect(data.value).toEqual('todos')
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not refetch if refetchOnMount is false', async () => {
+      const spy = vi.fn(async () => {
+        return 'todos'
+      })
+      const useTodoList = defineQuery({
+        key: ['todos'],
+        query: spy,
+        refetchOnMount: false,
+        staleTime: 100,
+      })
+      let returnedValues!: ReturnType<typeof useTodoList>
+
+      const pinia = createPinia()
+      const Component = defineComponent({
+        setup() {
+          returnedValues = useTodoList()
+          return {}
+        },
+        template: `<div></div>`,
+      })
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      await flushPromises()
+
+      const { data, status } = returnedValues
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(status.value).toBe('success')
+      expect(data.value).toEqual('todos')
+
+      mount(Component, {
+        global: {
+          plugins: [pinia, QueryPlugin],
+        },
+      })
+      expect(spy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('outside of components', () => {
+    let app: App
+    beforeEach(() => {
+      const pinia = createPinia()
+      app = createApp({ render: () => null })
+        .use(pinia)
+        .use(QueryPlugin)
+      app.mount(document.createElement('div'))
+    })
+    afterEach(() => {
+      app?.unmount()
+    })
+
+    it('reuses the query', async () => {
+      const useTodoList = defineQuery({
+        key: ['todos'],
+        query: async () => [{ id: 1 }],
+      })
+
+      // to have access to inject
+      app.runWithContext(() => {
+        const { data } = useTodoList()
+        expect(data).toBe(useTodoList().data)
+      })
+    })
+
+    it('reuses the query with a setup function', async () => {
+      const useTodoList = defineQuery(() => {
+        const todoFilter = ref<'all' | 'finished' | 'unfinished'>('all')
+        const { data, ...rest } = useQuery({
+          key: ['todos', { filter: todoFilter.value }],
+          query: async () => [{ id: 1 }],
+        })
+        return { ...rest, todoList: data, todoFilter }
+      })
+
+      app.runWithContext(() => {
+        const { todoList, todoFilter } = useTodoList()
+        expect(todoList).toBe(useTodoList().todoList)
+        expect(todoFilter).toBe(useTodoList().todoFilter)
+      })
+    })
+
+    it('refreshes the query when called', async () => {
+      const spy = vi.fn(async () => {
+        return 'todos'
+      })
+      const useTodoList = defineQuery({
+        key: ['todos'],
+        query: spy,
+        staleTime: 100,
+        refetchOnMount: true,
+      })
+
+      await app.runWithContext(async () => {
+        const { data, status } = useTodoList()
+        await flushPromises()
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        expect(status.value).toBe('success')
+        expect(data.value).toEqual('todos')
+
+        // should not trigger a refresh
+        useTodoList()
+        await flushPromises()
+        expect(spy).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(101)
+
+        useTodoList()
+        await flushPromises()
+        expect(spy).toHaveBeenCalledTimes(2)
+      })
+    })
   })
 })

--- a/src/define-query.ts
+++ b/src/define-query.ts
@@ -17,16 +17,14 @@ import { useQuery } from './use-query'
  * })
  * ```
  */
-export function defineQuery<
-  TResult,
-  TError = ErrorDefault,
->(
+export function defineQuery<TResult, TError = ErrorDefault>(
   options: UseQueryOptions<TResult, TError>,
 ): () => UseQueryReturn<TResult, TError>
 
 /**
  * Define a query with a setup function. Allows to return arbitrary values from the query function, create contextual
- * refs, rename the returned values, etc.
+ * refs, rename the returned values, etc. The setup function will be called only once, like stores, and **must be
+ * synchronous**.
  *
  * @param setup - a function to setup the query
  * @example
@@ -47,6 +45,9 @@ export function defineQuery<T>(setup: () => T): () => T
 export function defineQuery(
   optionsOrSetup: UseQueryOptions | (() => unknown),
 ): () => unknown {
-  const setupFn = typeof optionsOrSetup === 'function' ? optionsOrSetup : () => useQuery(optionsOrSetup)
+  const setupFn
+    = typeof optionsOrSetup === 'function'
+      ? optionsOrSetup
+      : () => useQuery(optionsOrSetup)
   return () => useQueryCache().ensureDefinedQuery(setupFn)
 }

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -223,9 +223,7 @@ export const useQueryCache = defineStore(QUERY_STORE_ID, () => {
     entry.options ??= options
 
     // if this query was defined within a defineQuery call, add it to the list
-    if (currentDefineQueryEntry) {
-      currentDefineQueryEntry[0].push(entry)
-    }
+    currentDefineQueryEntry?.[0].push(entry)
 
     return entry
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
 
   test: {
     environment: 'happy-dom',
+    fakeTimers: {
+      // easier to read, some date in 2001
+      now: 1_000_000_000_000,
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcovonly', 'html'],


### PR DESCRIPTION
I noticed that queries defined with `defineQuery` are not refreshed when the composable returned by `defineQuery` is called (for example on component mount). Indeed, since, in the case of a defined query, the setup function is only called once (at initiation of the defined query), the queries called inside the setup function are not called again when this composable is reused.

Therefore, in this PR I am testing an idea to address this, which consists in registering (in the `defineQueryMap`) the queries which are called by the setup function in order to refresh them when the defineQuery output composable is called.

**⚠️ Important note:** since the queries are registered by registering the queries called while the setup function is running (cf https://github.com/posva/pinia-colada/pull/40/files#diff-ac8c2f7434eefb694c9ead0745e4cd8297e90afe0a9a4c5ba4a54586c7e8596cR195), the current implementation implies that the setup function must be synchronous.