### PR TITLE
feat(use-query): Add enabled option

### DIFF
--- a/src/query-options.ts
+++ b/src/query-options.ts
@@ -1,4 +1,4 @@
-import { type InjectionKey, type MaybeRefOrGetter, inject } from 'vue'
+import { type InjectionKey, type MaybeRefOrGetter, type WatchSource, inject } from 'vue'
 import type { EntryKey } from './entry-options'
 import type { QueryPluginOptions } from './query-plugin'
 import type { ErrorDefault } from './types-extension'
@@ -61,6 +61,12 @@ export interface UseQueryOptions<TResult = unknown, TError = ErrorDefault> {
   query: (context: UseQueryFnContext) => Promise<TResult>
 
   /**
+   * Reactive boolean, indicating whether refetch/refresh should be called internally,
+   * calling refetch when toggled to true
+   */
+  enabled?: WatchSource<boolean>
+
+  /**
    * Time in ms after which the data is considered stale and will be refreshed on next read
    */
   staleTime?: number
@@ -106,6 +112,7 @@ export const USE_QUERY_DEFAULTS = {
   refetchOnWindowFocus: true as _RefetchOnControl,
   refetchOnReconnect: true as _RefetchOnControl,
   refetchOnMount: true as _RefetchOnControl,
+  enabled: (() => true) as WatchSource<boolean>,
   // as any to simplify the typing with generics
   transformError: (error: unknown) => error as any,
 } satisfies Partial<UseQueryOptions>

--- a/src/query-options.ts
+++ b/src/query-options.ts
@@ -1,4 +1,4 @@
-import { type InjectionKey, type MaybeRefOrGetter, type WatchSource, inject } from 'vue'
+import { type InjectionKey, type MaybeRefOrGetter, inject } from 'vue'
 import type { EntryKey } from './entry-options'
 import type { QueryPluginOptions } from './query-plugin'
 import type { ErrorDefault } from './types-extension'
@@ -64,7 +64,7 @@ export interface UseQueryOptions<TResult = unknown, TError = ErrorDefault> {
    * Reactive boolean, indicating whether refetch/refresh should be called internally,
    * calling refetch when toggled to true
    */
-  enabled?: WatchSource<boolean>
+  enabled?: MaybeRefOrGetter<boolean>
 
   /**
    * Time in ms after which the data is considered stale and will be refreshed on next read
@@ -112,7 +112,7 @@ export const USE_QUERY_DEFAULTS = {
   refetchOnWindowFocus: true as _RefetchOnControl,
   refetchOnReconnect: true as _RefetchOnControl,
   refetchOnMount: true as _RefetchOnControl,
-  enabled: (() => true) as WatchSource<boolean>,
+  enabled: true as MaybeRefOrGetter<boolean>,
   // as any to simplify the typing with generics
   transformError: (error: unknown) => error as any,
 } satisfies Partial<UseQueryOptions>

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -532,8 +532,8 @@ describe('useQuery', () => {
       expect(query).toHaveBeenCalledTimes(2)
     })
 
-    it('does not refresh/refetch when disabled', async () => {
-      const { wrapper, query } = mountDynamicKey({ enabled: () => false })
+    it('does not automatically refresh when enabled is false', async () => {
+      const { wrapper, query } = mountDynamicKey({ enabled: false })
 
       await flushPromises()
       expect(query).toBeCalledTimes(0)
@@ -547,7 +547,7 @@ describe('useQuery', () => {
       expect(query).toBeCalledTimes(1)
     })
 
-    it('refetches when enabled toggled', async () => {
+    it('triggers the query function when enabled becomes true', async () => {
       const enabled = ref(false)
       const { wrapper, query } = mountDynamicKey({ enabled })
 
@@ -563,6 +563,24 @@ describe('useQuery', () => {
       expect(query).toBeCalledTimes(2)
 
       // no refetch when value is not toggled
+      enabled.value = true
+      await nextTick()
+      await flushPromises()
+      expect(query).toBeCalledTimes(2)
+    })
+
+    it('does not trigger the query function when enabled becomes true if data is not stale', async () => {
+      const enabled = ref(true)
+      const { query } = mountDynamicKey({ enabled })
+
+      await flushPromises()
+      expect(query).toBeCalledTimes(1)
+
+      enabled.value = false
+      await nextTick()
+      await flushPromises()
+      expect(query).toBeCalledTimes(1)
+
       enabled.value = true
       await nextTick()
       await flushPromises()

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -532,6 +532,43 @@ describe('useQuery', () => {
       expect(query).toHaveBeenCalledTimes(2)
     })
 
+    it('does not refresh/refetch when disabled', async () => {
+      const { wrapper, query } = mountDynamicKey({ enabled: () => false })
+
+      await flushPromises()
+      expect(query).toBeCalledTimes(0)
+
+      // should refresh manually
+      await wrapper.vm.refresh()
+      await flushPromises()
+      expect(query).toBeCalledTimes(1)
+
+      await wrapper.vm.setId(2)
+      expect(query).toBeCalledTimes(1)
+    })
+
+    it('refetches when enabled toggled', async () => {
+      const enabled = ref(false)
+      const { wrapper, query } = mountDynamicKey({ enabled })
+
+      await flushPromises()
+      expect(query).toBeCalledTimes(0)
+
+      enabled.value = true
+      await nextTick()
+      await flushPromises()
+      expect(query).toBeCalledTimes(1)
+
+      await wrapper.vm.setId(2)
+      expect(query).toBeCalledTimes(2)
+
+      // no refetch when value is not toggled
+      enabled.value = true
+      await nextTick()
+      await flushPromises()
+      expect(query).toBeCalledTimes(1)
+    })
+
     it.todo('can avoid throwing', async () => {
       const { wrapper, query } = mountSimple({
         staleTime: 0,

--- a/src/use-query.ts
+++ b/src/use-query.ts
@@ -3,7 +3,6 @@ import {
   computed,
   getCurrentInstance,
   getCurrentScope,
-isRef,
   onMounted,
   onScopeDispose,
   onServerPrefetch,
@@ -76,8 +75,7 @@ export function useQuery<TResult, TError = ErrorDefault>(
 
   // if passed by client
   // & check if watchable
-  if (_options.enabled !== undefined
-      && (isRef(options.enabled) || typeof options.enabled === 'function')) {
+  if (_options.enabled !== undefined && typeof options.enabled !== 'boolean') {
     watch(options.enabled, (newEnabled, oldEnabled) => {
       // add test case why we check !oldEnabled
       // add test case when we update entry, add test case when we update enabled
@@ -184,13 +182,11 @@ export function useQuery<TResult, TError = ErrorDefault>(
   if (IS_CLIENT) {
     if (options.refetchOnWindowFocus) {
       useEventListener(document, 'visibilitychange', () => {
-        if (document.visibilityState === 'visible') {
-          if (toValue(options.enabled)) {
-            if (options.refetchOnWindowFocus === 'always') {
-              refetch()
-            } else {
-              refresh()
-            }
+        if (document.visibilityState === 'visible' && toValue(options.enabled)) {
+          if (options.refetchOnWindowFocus === 'always') {
+            refetch()
+          } else {
+            refresh()
           }
         }
       })
@@ -198,10 +194,12 @@ export function useQuery<TResult, TError = ErrorDefault>(
 
     if (options.refetchOnReconnect) {
       useEventListener(window, 'online', () => {
-        if (options.refetchOnReconnect === 'always' && toValue(options.enabled)) {
-          refetch()
-        } else {
-          refresh()
+        if (toValue(options.enabled)) {
+          if (options.refetchOnReconnect === 'always') {
+            refetch()
+          } else {
+            refresh()
+          }
         }
       })
     }

--- a/src/use-query.ts
+++ b/src/use-query.ts
@@ -73,9 +73,7 @@ export function useQuery<TResult, TError = ErrorDefault>(
   const refresh = () => store.refresh(entry.value)
   const refetch = () => store.refetch(entry.value)
 
-  // if passed by client
-  // & check if watchable
-  if (_options.enabled !== undefined && typeof options.enabled !== 'boolean') {
+  if (typeof options.enabled !== 'boolean') {
     watch(options.enabled, (newEnabled, oldEnabled) => {
       // add test case why we check !oldEnabled
       // add test case when we update entry, add test case when we update enabled


### PR DESCRIPTION
Close #42 

I have opened this PR to introduce an 'enable' option for the `useQuery` feature. This option will allow users to toggle the `useQuery` refetch/refresh internal behavior on or off based on their requirements.

I have added unit tests to ensure the new option works as expected and I will update the documentation accordingly after merging.

Please review the changes and provide any feedback or suggestions you may have.