### PR TITLE
chore(playground): fix the playground auto routers error

### DIFF
--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import { createRouter, createWebHistory } from 'vue-router/auto'
+import { routes } from 'vue-router/auto-routes'
 import { createPinia } from 'pinia'
 import { QueryPlugin } from '@pinia/colada'
 import './style.css'
@@ -10,6 +11,7 @@ import App from './App.vue'
 const app = createApp(App)
 const router = createRouter({
   history: createWebHistory(),
+  routes,
 })
 
 app.use(createPinia())


### PR DESCRIPTION
When I try to launch the playground in the project. It reported an error because routes were not import from auto-routes