### PR TITLE
docs: ensure jump link works correctly for reusable-queries section

### DIFF
--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -4,7 +4,7 @@ Queries handle async state declaratively. They let you focus on the state, its a
 
 Queries are meant to **read** data. In terms of REST, for example, queries would handle `GET` requests. If you need to **write** (or mutate) data, use [mutations](./mutations.md).
 
-Queries can be created with `useQuery()` or [`defineQuery()`](#reusable-queries).
+Queries can be created with `useQuery()` or [`defineQuery()`](#Reusable-Queries).
 
 ```vue twoslash
 <script setup lang="ts">


### PR DESCRIPTION
## Description

Hi everyone, thanks for the great work!

I noticed that the jump link `[defineQuery()](#reusable-queries)` on the [Queries](https://pinia-colada.esm.dev/guide/queries.html) page wasn't working due to a case-sensitivity issue. This PR aims to resolve this by updating the `href` to `#Reusable-Queries`.

Feel free to close this if it's unnecessary

**After**

https://github.com/user-attachments/assets/aae26977-69b7-4b7c-866e-d803e7886326
