### PR TITLE
feat(plugins): add auto-refetch plugin

### DIFF
--- a/plugins/auto-refetch/README.md
+++ b/plugins/auto-refetch/README.md
@@ -24,7 +24,7 @@ import { PiniaColadaAutoRefetch } from '@pinia/colada-plugin-auto-refetch'
 app.use(PiniaColada, {
   // ...
   plugins: [
-    PiniaColadaAutoRefetch(),
+    PiniaColadaAutoRefetch({ autoRefetch: true }), // enable globally
   ],
 })
 ```

--- a/plugins/auto-refetch/README.md
+++ b/plugins/auto-refetch/README.md
@@ -35,7 +35,7 @@ You can customize the refetch behavior individually for each query with the `aut
 useQuery({
   key: ['todos'],
   query: getTodos,
-  autoRefetch: false, // disable auto refetch
+  autoRefetch: true, // override local autoRefetch
 })
 ```
 

--- a/plugins/auto-refetch/README.md
+++ b/plugins/auto-refetch/README.md
@@ -1,0 +1,44 @@
+<h1>
+  <img height="76" src="https://github.com/posva/pinia-colada/assets/664177/02011637-f94d-4a35-854a-02f7aed86a3c" alt="Pinia Colada logo">
+  Pinia Colada Auto Refetch
+</h1>
+
+<a href="https://npmjs.com/package/@pinia/colada-plugin-auto-refetch">
+  <img src="https://badgen.net/npm/v/@pinia/colada-plugin-auto-refetch/latest" alt="npm package">
+</a>
+
+Automatically refetch queries when they become stale in Pinia Colada.
+
+## Installation
+
+```sh
+npm install @pinia/colada-plugin-auto-refetch
+```
+
+## Usage
+
+```js
+import { PiniaColadaAutoRefetch } from '@pinia/colada-plugin-auto-refetch'
+
+// Pass the plugin to Pinia Colada options
+app.use(PiniaColada, {
+  // ...
+  plugins: [
+    PiniaColadaAutoRefetch(),
+  ],
+})
+```
+
+You can customize the refetch behavior individually for each query with the `autoRefetch` option:
+
+```ts
+useQuery({
+  key: ['todos'],
+  query: getTodos,
+  autoRefetch: false, // disable auto refetch
+})
+```
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT)

--- a/plugins/auto-refetch/package.json
+++ b/plugins/auto-refetch/package.json
@@ -60,7 +60,7 @@
   "scripts": {
     "build": "tsup",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l @pinia/colada-plugin-auto-refetch -r 1",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest --ui"
   },
   "peerDependencies": {
     "@pinia/colada": "workspace:^"

--- a/plugins/auto-refetch/package.json
+++ b/plugins/auto-refetch/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "@pinia/colada-plugin-auto-refetch",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "0.0.1",
+  "description": "Automatically refetch queries when they become stale in Pinia Colada",
+  "author": {
+    "name": "Yusuf Mansur Ozer",
+    "email": "ymansurozer@gmail.com"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/posva/pinia-colada/plugins/auto-refetch#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/posva/pinia-colada.git"
+  },
+  "bugs": {
+    "url": "https://github.com/posva/pinia-colada/issues"
+  },
+  "keywords": [
+    "pinia",
+    "plugin",
+    "data",
+    "fetching",
+    "query",
+    "mutation",
+    "cache",
+    "layer",
+    "refetch"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l @pinia/colada-plugin-auto-refetch -r 1",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "peerDependencies": {
+    "@pinia/colada": "workspace:^"
+  },
+  "devDependencies": {
+    "@pinia/colada": "workspace:^"
+  }
+}

--- a/plugins/auto-refetch/src/auto-refetch.spec.ts
+++ b/plugins/auto-refetch/src/auto-refetch.spec.ts
@@ -70,7 +70,7 @@ describe('Auto Refetch plugin', () => {
     expect(query).toHaveBeenCalledTimes(2)
   })
 
-  it('respects disabled option globally', async () => {
+  it('respects enabled option globally', async () => {
     const { query } = mountQuery(
       {
         staleTime: 1000,

--- a/plugins/auto-refetch/src/auto-refetch.spec.ts
+++ b/plugins/auto-refetch/src/auto-refetch.spec.ts
@@ -42,10 +42,13 @@ describe('Auto Refetch plugin', () => {
         global: {
           plugins: [
             createPinia(),
-            [PiniaColada, {
-              plugins: [PiniaColadaAutoRefetch({ autoRefetch: true, ...pluginOptions })],
-              ...pluginOptions,
-            }],
+            [
+              PiniaColada,
+              {
+                plugins: [PiniaColadaAutoRefetch({ autoRefetch: true, ...pluginOptions })],
+                ...pluginOptions,
+              },
+            ],
           ],
         },
       },
@@ -128,7 +131,7 @@ describe('Auto Refetch plugin', () => {
   })
 
   it('resets the stale timer when a new request occurs', async () => {
-    const { query } = mountQuery({
+    const { query, wrapper } = mountQuery({
       staleTime: 1000,
     })
 
@@ -141,12 +144,13 @@ describe('Auto Refetch plugin', () => {
 
     // Manually trigger a new request
     query.mockImplementationOnce(async () => 'new result')
-    await query()
+    await wrapper.vm.refetch()
     await flushPromises()
     expect(query).toHaveBeenCalledTimes(2)
+    expect(wrapper.vm.data).toBe('new result')
 
-    // Advance time to what would have been the original stale time (500ms more)
-    vi.advanceTimersByTime(500)
+    // Advance time to surpass the original stale time
+    vi.advanceTimersByTime(700)
     await flushPromises()
     // Should not have triggered another request yet
     expect(query).toHaveBeenCalledTimes(2)

--- a/plugins/auto-refetch/src/auto-refetch.spec.ts
+++ b/plugins/auto-refetch/src/auto-refetch.spec.ts
@@ -102,7 +102,7 @@ describe('Auto Refetch plugin', () => {
     expect(query).toHaveBeenCalledTimes(1)
   })
 
-  it('cleans up timeouts when query is unmounted', async () => {
+  it('avoids refetching an unactive query', async () => {
     const { wrapper, query } = mountQuery({
       staleTime: 1000,
     })

--- a/plugins/auto-refetch/src/auto-refetch.spec.ts
+++ b/plugins/auto-refetch/src/auto-refetch.spec.ts
@@ -1,0 +1,129 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { createPinia } from 'pinia'
+import { useQuery, PiniaColada } from '@pinia/colada'
+import type { UseQueryOptions } from '@pinia/colada'
+import type { PiniaColadaAutoRefetchOptions } from '.'
+import { PiniaColadaAutoRefetch } from '.'
+
+describe('Auto Refetch plugin', () => {
+  beforeEach(() => {
+    vi.clearAllTimers()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  enableAutoUnmount(afterEach)
+
+  function mountQuery(
+    queryOptions?: Partial<UseQueryOptions>,
+    pluginOptions?: PiniaColadaAutoRefetchOptions,
+  ) {
+    const query = vi.fn(async () => 'result')
+    const wrapper = mount(
+      defineComponent({
+        template: '<div></div>',
+        setup() {
+          return useQuery({
+            query,
+            key: ['test'],
+            ...queryOptions,
+          })
+        },
+      }),
+      {
+        global: {
+          plugins: [
+            createPinia(),
+            [PiniaColada, {
+              plugins: [PiniaColadaAutoRefetch(pluginOptions)],
+              ...pluginOptions,
+            }],
+          ],
+        },
+      },
+    )
+
+    return { wrapper, query }
+  }
+
+  it('automatically refetches when stale time is reached', async () => {
+    const { query } = mountQuery({
+      staleTime: 1000,
+    })
+
+    // Wait for initial query
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // Advance time past stale time in one go
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+
+    expect(query).toHaveBeenCalledTimes(2)
+  })
+
+  it('respects disabled option globally', async () => {
+    const { query } = mountQuery(
+      {
+        staleTime: 1000,
+      },
+      {
+        enabled: false,
+      },
+    )
+
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('respects disabled option per query', async () => {
+    const { query } = mountQuery({
+      staleTime: 1000,
+      autoRefetch: false,
+    })
+
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('cleans up timeouts when query is unmounted', async () => {
+    const { wrapper, query } = mountQuery({
+      staleTime: 1000,
+    })
+
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    wrapper.unmount()
+    vi.advanceTimersByTime(2000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not refetch when staleTime is not set', async () => {
+    const { query } = mountQuery({})
+
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+})

--- a/plugins/auto-refetch/src/index.ts
+++ b/plugins/auto-refetch/src/index.ts
@@ -7,7 +7,7 @@ export interface PiniaColadaAutoRefetchOptions {
    * Whether to enable auto refresh by default.
    * @default false
    */
-  enabled?: boolean
+  autoRefetch?: boolean
 }
 
 /**

--- a/plugins/auto-refetch/src/index.ts
+++ b/plugins/auto-refetch/src/index.ts
@@ -16,7 +16,7 @@ export interface PiniaColadaAutoRefetchOptions {
 export function PiniaColadaAutoRefetch(
   options: PiniaColadaAutoRefetchOptions = {},
 ): PiniaColadaPlugin {
-  const { enabled = false } = options
+  const { autoRefetch = false } = options
 
   return ({ queryCache }) => {
     // Keep track of active entries and their timeouts
@@ -55,9 +55,10 @@ export function PiniaColadaAutoRefetch(
        * Whether to schedule a refetch for the given entry
        */
       const shouldScheduleRefetch = (options: UseQueryOptions) => {
-        const queryEnabled = options.autoRefetch ?? enabled
+        if (!options) return false
+        const queryEnabled = options.autoRefetch ?? autoRefetch
         const staleTime = options.staleTime
-        return queryEnabled && staleTime
+        return Boolean(queryEnabled && staleTime)
       }
 
       // Trigger a fetch on creation to enable auto-refetch on initial load

--- a/plugins/auto-refetch/src/index.ts
+++ b/plugins/auto-refetch/src/index.ts
@@ -1,0 +1,78 @@
+import type { PiniaColadaPlugin } from '@pinia/colada'
+
+export interface PiniaColadaAutoRefetchOptions {
+  /**
+   * Whether to enable auto refresh by default.
+   * @default true
+   */
+  enabled?: boolean
+}
+
+/**
+ * Plugin that automatically refreshes queries when they become stale
+ */
+export function PiniaColadaAutoRefetch(
+  options: PiniaColadaAutoRefetchOptions = {},
+): PiniaColadaPlugin {
+  const { enabled = true } = options
+
+  return ({ queryCache }) => {
+    // Keep track of active entries and their timeouts
+    const refetchTimeouts = new Map<string, NodeJS.Timeout>()
+
+    queryCache.$onAction(({ name, args, after }) => {
+      // We want refetch to happen only on the client
+      if (!import.meta.client) return
+
+      // Handle fetch to set up auto-refetch
+      if (name === 'refresh') {
+        const [entry] = args
+        const key = entry.key.join('/')
+
+        after(async () => {
+          // Skip if auto-refetch is disabled or if the query has no stale time
+          const queryEnabled = entry.options?.autoRefetch ?? enabled
+          const staleTime = entry.options?.staleTime
+          if (!queryEnabled || !staleTime || !entry.active) return
+
+          // Clear any existing timeout for this key
+          const existingTimeout = refetchTimeouts.get(key)
+          if (existingTimeout) {
+            clearTimeout(existingTimeout)
+          }
+
+          // Schedule next refetch
+          const timeout = setTimeout(() => {
+            if (entry.active && entry.options) {
+              queryCache.refresh(entry).catch(console.error)
+              refetchTimeouts.delete(key)
+            }
+          }, staleTime)
+
+          refetchTimeouts.set(key, timeout)
+        })
+      }
+
+      // Clean up timeouts when entry is removed
+      if (name === 'remove') {
+        const [entry] = args
+        const key = entry.key.join('/')
+        const timeout = refetchTimeouts.get(key)
+        if (timeout) {
+          clearTimeout(timeout)
+          refetchTimeouts.delete(key)
+        }
+      }
+    })
+  }
+}
+
+// Add types for the new option
+declare module '@pinia/colada' {
+  interface UseQueryOptions {
+    /**
+     * Whether to automatically refresh this query when it becomes stale.
+     */
+    autoRefetch?: boolean
+  }
+}

--- a/plugins/auto-refetch/tsup.config.ts
+++ b/plugins/auto-refetch/tsup.config.ts
@@ -1,0 +1,19 @@
+import { type Options, defineConfig } from 'tsup'
+
+const commonOptions = {
+  // splitting: false,
+  sourcemap: true,
+  format: ['cjs', 'esm'],
+  external: ['vue', 'pinia', '@pinia/colada'],
+  dts: true,
+  target: 'esnext',
+} satisfies Options
+
+export default defineConfig([
+  {
+    ...commonOptions,
+    clean: true,
+    entry: ['src/index.ts'],
+    globalName: 'PiniaColadaAutoRefetch',
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,6 +233,12 @@ importers:
         specifier: workspace:^
         version: link:../..
 
+  plugins/auto-refetch:
+    devDependencies:
+      '@pinia/colada':
+        specifier: workspace:^
+        version: link:../..
+
   plugins/cache-persister:
     devDependencies:
       '@pinia/colada':


### PR DESCRIPTION
Closes #49.

This PR adds a new plugin that enables automatic query refetching when data becomes stale. This provides a simple way to keep data fresh without manual intervention.

**Features**
- Automatically refreshes queries when their staleTime is reached
- Can be enabled/disabled globally via plugin options
- Can be controlled per-query via autoRefetch option
- Cleans up properly when queries are unmounted
- Only runs on the client side

**Issues and Questions**
- I am having an issue with one of the tests. To be honest, I am not good with writing tests (this is one of the rare cases where I've written one). So some help would be great!
- The refetch timeout is currently set in `refresh` hook. I also tried `fetch` but the issue was `fetch` is not triggered on initial page load but `refresh` does. So even if the user does nothing regarding the query from initial load, it will be auto-fetched in the background.
- To trigger a refresh, I've used `queryCache.refresh(entry)`. I noticed there are also options like `fetch`, `invalidate`, and `invalidateQueries`. I used `refresh` because I understand it has an internal check on the data to see if it is fresh. I did not want to force it with `fetch`.
- The refetch timeouts are only set on the client. I think this should be the expected behavior, as otherwise the refetch keeps happening on the server, too.

I would love your feedback on this. I am happy to work on this further.