### PR TITLE
feat(query): staleTime of Infinity always fresh.

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import fs from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { dirname, join } from 'node:path'

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -282,7 +282,11 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
           ext: START_EXT,
           options,
           get stale() {
-            return Date.now() >= this.when + this.options!.staleTime
+            const staleTime = this.options!.staleTime
+            if (staleTime === Infinity) {
+              return this.when === 0
+            }
+            return Date.now() >= this.when + staleTime
           },
           get active() {
             return this.deps.size > 0
@@ -810,7 +814,11 @@ export function createQueryEntry<TResult = unknown, TError = ErrorDefault>(
     ext: START_EXT,
     options,
     get stale() {
-      return Date.now() >= this.when + this.options!.staleTime
+      const staleTime = this.options!.staleTime
+      if (staleTime === Infinity) {
+        return this.when === 0
+      }
+      return Date.now() >= this.when + staleTime
     },
     get active() {
       return this.deps.size > 0

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -263,6 +263,20 @@ describe('useQuery', () => {
 
       expect(query).toHaveBeenCalledTimes(2)
     })
+
+    it('does not fetch if staleTime is Infinity', async () => {
+      const { wrapper, query } = mountSimple({ staleTime: Infinity })
+
+      await flushPromises()
+      expect(query).toHaveBeenCalledTimes(1)
+
+      // should not trigger a new fetch because staleTime is Infinity, even if so long time has passed
+      vi.advanceTimersByTime(24 * 60 * 60 * 1000)
+      wrapper.vm.refresh()
+      await flushPromises()
+
+      expect(query).toHaveBeenCalledTimes(1)
+    })
   })
 
   describe('gcTime', () => {


### PR DESCRIPTION
This PR modifies the `staleTime` option to accept `Infinity` as a valid value. If `Infinity` is specified, the cache will remain fresh indefinitely after the initial fetch, unless manually refetched.

This is useful in cases where the data doesn't update frequently, so refetching is unnecessary, and we may want to disable it for performance reasons.

I welcome your feedback on this change and am happy to make any necessary adjustments.