### PR TITLE
bug/should-refetch-on-each-mount

### DIFF
--- a/src/define-query.spec.ts
+++ b/src/define-query.spec.ts
@@ -143,6 +143,40 @@ describe('defineQuery', () => {
       expect(spy).toHaveBeenCalledTimes(2)
     })
 
+    it('triggers as many times as it is mounted', async () => {
+      const spy = vi.fn(async () => 'ko')
+      const useDefinedQuery = defineQuery({
+        key: ['id'],
+        query: spy,
+      })
+
+      const pinia = createPinia()
+
+      const Comp1 = defineComponent({
+        setup() {
+          useDefinedQuery()
+          return {}
+        },
+        template: `<div></div>`,
+      })
+
+      const mountedComponent = mount(Comp1, {
+        global: {
+          plugins: [pinia, PiniaColada],
+        },
+      })
+      mountedComponent.unmount()
+      mount(Comp1, {
+        global: {
+          plugins: [pinia, PiniaColada],
+        },
+      })
+
+      await flushPromises()
+
+      expect(spy).toHaveBeenCalledTimes(2)
+    })
+
     it('refetches if refetchOnMount is always', async () => {
       const spy = vi.fn(async () => {
         return 'todos'


### PR DESCRIPTION
#### Description

This PR adds a test for the `defineQuery` method.
It shows the behaviour of the query function when mounting/unmounting a component multiple times. 
As result we can see the test fails and the query method is only called on the first `mount`.

#### Expected behaviour

It should refetch the data with each onMounted

PD: Further investigation made me noticed it would refetch again on mount only if the key is not active in the cache anymore. 

@posva Thanks for creating this library. It is changing the way we do data-fetching in our team 🎉 