### PR TITLE
feat(plugins): Add refetch interval plugin

### DIFF
--- a/playground/src/composables/contacts.ts
+++ b/playground/src/composables/contacts.ts
@@ -13,6 +13,7 @@ export const useContactSearch = defineQuery(() => {
     // avoids displaying the "Loading..." too quickly
     // makes your app look more responsive
     delay: 200,
+    refetchInterval: 15000,
   })
   return { ...query, searchText }
 })

--- a/playground/src/main.ts
+++ b/playground/src/main.ts
@@ -10,6 +10,7 @@ import { PiniaColadaRetry } from '@pinia/colada-plugin-retry'
 import App from './App.vue'
 import { PiniaColadaDebugPlugin } from '@pinia/colada-plugin-debug'
 import { PiniaColadaDelay } from '@pinia/colada-plugin-delay'
+import { PiniaColadaRefetchInterval } from '@pinia/colada-plugin-refetch-interval'
 
 const app = createApp(App)
 const router = createRouter({
@@ -26,6 +27,7 @@ app.use(PiniaColada, {
     PiniaColadaQueryHooksPlugin({
       onSettled() {},
     }),
+    PiniaColadaRefetchInterval(),
   ],
 })
 app.use(router)

--- a/plugins/refetch-interval/CHANGELOG.md
+++ b/plugins/refetch-interval/CHANGELOG.md
@@ -1,0 +1,9 @@
+## 0.0.1 (2025-01-07)
+
+
+### Features
+
+* Add base refetch interval plugin ([517e80f](https://github.com/posva/pinia-colada/commit/517e80fa9fae0f0f51b008a0c31e9e134bc9b876))
+
+
+

--- a/plugins/refetch-interval/README.md
+++ b/plugins/refetch-interval/README.md
@@ -1,0 +1,48 @@
+<h1>
+  <img height="76" src="https://github.com/posva/pinia-colada/assets/664177/02011637-f94d-4a35-854a-02f7aed86a3c" alt="Pinia Colada logo">
+  Pinia Colada Refetch Interval
+</h1>
+
+<a href="https://npmjs.com/package/@pinia/colada-plugin-refetch-interval">
+  <img src="https://badgen.net/npm/v/@pinia/colada-plugin-refetch-interval/latest" alt="npm package">
+</a>
+
+Refetch queries on a regular interval with your Pinia Colada.
+
+## Installation
+
+```sh
+npm install @pinia/colada-plugin-refetch-interval
+```
+
+## Usage
+
+```js
+import { PiniaColadaRefetchInterval } from '@pinia/colada-plugin-refetch-interval'
+
+// Pass the plugin to Pinia Colada options
+app.use(PiniaColada, {
+  // ...
+  plugins: [
+    PiniaColadaRefetchInterval({
+      refetchInterval: 1000, // Optional, defaults to false
+      refetchIntervalInBackground: true, // Optional, defaults to false
+    }),
+  ],
+})
+```
+
+You can customize the refetch interval behavior individually for each query/mutation with the `refetchInterval` option:
+
+```ts
+useQuery({
+  key: ['todos'],
+  query: getTodos,
+  refetchInterval: 1000, // Optional, defaults to false
+  refetchIntervalInBackground: true, // Optional, defaults to false
+})
+```
+
+## License
+
+[MIT](http://opensource.org/licenses/MIT)

--- a/plugins/refetch-interval/package.json
+++ b/plugins/refetch-interval/package.json
@@ -1,0 +1,73 @@
+{
+  "name": "@pinia/colada-plugin-refetch-interval",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "version": "0.0.1",
+  "description": "Refetch queries on a regular interval with Pinia Colada",
+  "author": {
+    "name": "Eduardo San Martin Morote",
+    "email": "posva13@gmail.com"
+  },
+  "license": "MIT",
+  "funding": "https://github.com/sponsors/posva",
+  "homepage": "https://github.com/posva/pinia-colada/plugins/refetch-interval#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/posva/pinia-colada.git"
+  },
+  "bugs": {
+    "url": "https://github.com/posva/pinia-colada/issues"
+  },
+  "keywords": [
+    "pinia",
+    "plugin",
+    "data",
+    "fetching",
+    "interval",
+    "refetch",
+    "query",
+    "mutation",
+    "cache",
+    "layer"
+  ],
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": {
+        "import": "./dist/index.d.ts",
+        "require": "./dist/index.d.cts"
+      },
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s --commit-path . -l @pinia/colada-plugin-refetch-interval -r 1",
+    "test": "vitest --ui"
+  },
+  "peerDependencies": {
+    "@pinia/colada": "workspace:^"
+  },
+  "devDependencies": {
+    "@pinia/colada": "workspace:^"
+  }
+}

--- a/plugins/refetch-interval/src/index.ts
+++ b/plugins/refetch-interval/src/index.ts
@@ -1,0 +1,141 @@
+import type { PiniaColadaPluginContext } from '@pinia/colada'
+import { toValue } from 'vue'
+/**
+ * @module @pinia/colada-plugin-refetch-interval
+ */
+
+/**
+ * Options for the Pinia Colada Refetch Interval plugin.
+ */
+export interface RefetchIntervalOptions {
+  /**
+   * If set to a number, queries will continuously refetch at this frequency in milliseconds.
+   * If set to false, no automatic refetching will occur.
+   */
+  refetchInterval?: number | false
+  /**
+   * If true, queries will continue to refetch while their tab/window is in the background.
+   */
+  refetchIntervalInBackground?: boolean
+}
+
+interface IntervalEntry {
+  timeoutId: ReturnType<typeof setTimeout>
+  lastUpdated: number
+}
+
+const REFETCH_INTERVAL_OPTIONS_DEFAULTS = {
+  refetchInterval: false,
+  refetchIntervalInBackground: false,
+} satisfies Required<RefetchIntervalOptions>
+
+/**
+ * Plugin that adds the ability to refetch queries at regular intervals.
+ *
+ * @param globalOptions - global options for the intervals
+ */
+export function PiniaColadaRefetchInterval(
+  globalOptions?: RefetchIntervalOptions,
+): (context: PiniaColadaPluginContext) => void {
+  const defaults = { ...REFETCH_INTERVAL_OPTIONS_DEFAULTS, ...globalOptions }
+
+  return ({ queryCache }) => {
+    const intervalMap = new Map<string, IntervalEntry>()
+
+    let isDocumentVisible = typeof document !== 'undefined'
+      ? document.visibilityState === 'visible'
+      : true
+
+    if (typeof document !== 'undefined') {
+      const visibilityCallback = () => {
+        isDocumentVisible = document.visibilityState === 'visible'
+      }
+      document.addEventListener('visibilitychange', visibilityCallback)
+    }
+
+    queryCache.$onAction(({ name, args, after }) => {
+      // cleanup intervals when data is deleted
+      if (name === 'remove') {
+        const [cacheEntry] = args
+        const key = cacheEntry.key.join('/')
+        const entry = intervalMap.get(key)
+        if (entry) {
+          clearTimeout(entry.timeoutId)
+          intervalMap.delete(key)
+        }
+      }
+
+      // Continue only if the action is a fetch
+      if (name !== 'fetch') {
+        return
+      }
+
+      const [queryEntry] = args
+
+      // Get local options, falling back to global defaults
+      const localOptions = queryEntry.options as RefetchIntervalOptions
+      const options = {
+        refetchInterval: localOptions?.refetchInterval ?? defaults.refetchInterval,
+        refetchIntervalInBackground: localOptions?.refetchIntervalInBackground ?? defaults.refetchIntervalInBackground,
+      } satisfies RefetchIntervalOptions
+
+      const key = queryEntry.key.join('/')
+
+      // Clear any existing interval
+      const existingInterval = intervalMap.get(key)
+      if (existingInterval) {
+        clearTimeout(existingInterval.timeoutId)
+        intervalMap.delete(key)
+      }
+
+      // If refetchInterval is false or not a number, don't set up a new interval
+      if (!options.refetchInterval || typeof options.refetchInterval !== 'number') return
+
+      after(() => {
+        // Only set up new interval if the fetch was successful and the query is enabled
+        if (queryEntry.state.value.status === 'success' && toValue(queryEntry.options?.enabled)) {
+          const setupNextInterval = () => {
+            const entry: IntervalEntry = {
+              lastUpdated: Date.now(),
+              timeoutId: setTimeout(() => {
+                // Only refetch if refetchIntervalInBackground is true or document is visible
+                if (options.refetchIntervalInBackground || isDocumentVisible) {
+                  Promise.resolve(queryCache.fetch(queryEntry))
+                    .catch(process.env.NODE_ENV !== 'test' ? console.error : () => {})
+                    .finally(() => {
+                      // Setup next interval after completion
+                      setupNextInterval()
+                    })
+                } else {
+                  // If we can't refetch now, try again after the interval
+                  // setupNextInterval()
+
+                  // If we can't refetch now, invalidate the query
+                  queryCache.invalidate(queryEntry)
+                }
+              }, options.refetchInterval || 0),
+            }
+            intervalMap.set(key, entry)
+          }
+
+          setupNextInterval()
+        }
+      })
+    })
+  }
+}
+
+declare module '@pinia/colada' {
+  // eslint-disable-next-line unused-imports/no-unused-vars
+  export interface UseQueryOptions<TResult, TError> {
+    /**
+     * If set to a number, queries will continuously refetch at this frequency in milliseconds.
+     * If set to false, no automatic refetching will occur.
+     */
+    refetchInterval?: number | false
+    /**
+     * If true, queries will continue to refetch while their tab/window is in the background.
+     */
+    refetchIntervalInBackground?: boolean
+  }
+}

--- a/plugins/refetch-interval/src/refetchInterval.spec.ts
+++ b/plugins/refetch-interval/src/refetchInterval.spec.ts
@@ -1,0 +1,518 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent } from 'vue'
+import { createPinia } from 'pinia'
+import { useQuery, PiniaColada } from '@pinia/colada'
+import type { PiniaColadaOptions, UseQueryOptions } from '@pinia/colada'
+import { PiniaColadaRefetchInterval } from '.'
+
+describe('Refetch Interval plugin', () => {
+  beforeEach(() => {
+    vi.clearAllTimers()
+    vi.useFakeTimers()
+  })
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  enableAutoUnmount(afterEach)
+
+  function factory(options: PiniaColadaOptions, queryOptions?: UseQueryOptions) {
+    const pinia = createPinia()
+    const wrapper = mount(
+      defineComponent({
+        template: '<div></div>',
+        setup() {
+          return {
+            ...useQuery(
+              queryOptions || {
+                query: async () => 42,
+                key: ['key'],
+              },
+            ),
+          }
+        },
+      }),
+      {
+        global: {
+          plugins: [pinia, [PiniaColada, options]],
+        },
+      },
+    )
+
+    return { pinia, wrapper }
+  }
+
+  it('should refetch data at specified intervals', async () => {
+    const query = vi.fn(async () => 'ok')
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 1000,
+          }),
+        ],
+      },
+      {
+        key: ['key'],
+        query,
+      },
+    )
+
+    // Initial fetch
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.data).toBe('ok')
+
+    // Wait for first interval
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(2)
+
+    // Wait for second interval
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(3)
+
+    wrapper.unmount()
+  })
+
+  it('should respect per-query interval settings over global settings', async () => {
+    const query = vi.fn(async () => 'ok')
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 5000,
+          }),
+        ],
+      },
+      {
+        key: ['key'],
+        query,
+        refetchInterval: 1000,
+      },
+    )
+
+    // Initial fetch
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // Wait for local interval (1s)
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(2)
+
+    // Wait for next 4 seconds, checking each interval
+    for (let i = 0; i < 4; i++) {
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+    }
+    expect(query).toHaveBeenCalledTimes(6)
+
+    wrapper.unmount()
+  })
+
+  it('should stop refetching when query is removed', async () => {
+    const query = vi.fn(async () => 'ok')
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 1000,
+          }),
+        ],
+      },
+      {
+        key: ['key'],
+        query,
+      },
+    )
+
+    // Initial fetch
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // Unmount component (triggers cleanup)
+    wrapper.unmount()
+    vi.clearAllTimers() // Ensure timers are cleared immediately after unmount
+    await flushPromises() // Ensure cleanup is complete
+
+    // Wait for what would have been multiple intervals
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1) // Should not have increased
+  })
+
+  it('should not set up interval if refetchInterval is false', async () => {
+    const query = vi.fn(async () => 'ok')
+    const { wrapper } = factory(
+      {
+        plugins: [PiniaColadaRefetchInterval()],
+      },
+      {
+        key: ['key'],
+        query,
+        refetchInterval: false,
+      },
+    )
+
+    // Initial fetch
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+
+    // Wait for some time
+    vi.advanceTimersByTime(5000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1) // Should not have increased
+
+    wrapper.unmount()
+  })
+
+  it('should handle failed queries gracefully', async () => {
+    let shouldFail = false
+    const query = vi.fn(async () => {
+      if (shouldFail) throw new Error('Query failed')
+      return 'ok'
+    })
+
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 1000,
+          }),
+        ],
+      },
+      {
+        key: ['key'],
+        query,
+      },
+    )
+
+    // Initial successful fetch
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.data).toBe('ok')
+
+    // Make next query fail
+    shouldFail = true
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(2)
+    expect(wrapper.vm.error).toBeTruthy()
+
+    // Should continue trying
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(3)
+
+    wrapper.unmount()
+  })
+
+  it('should not refetch if enabled: false', async () => {
+    const spy = vi.fn(async () => 42)
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 1000,
+          }),
+        ],
+      },
+      {
+        query: spy,
+        key: ['key'],
+        enabled: false,
+        refetchInterval: 1000,
+      },
+    )
+
+    // Initial fetch should not happen because enabled is false
+    await flushPromises()
+    expect(spy).toHaveBeenCalledTimes(0)
+
+    // Wait for what would have been multiple intervals
+    vi.advanceTimersByTime(3000)
+    await flushPromises()
+    expect(spy).toHaveBeenCalledTimes(0)
+
+    wrapper.unmount()
+  })
+
+  it('should ensure interval restarts after manual refetch', async () => {
+    const spy = vi.fn(async () => 42)
+    const { wrapper } = factory(
+      {
+        plugins: [
+          PiniaColadaRefetchInterval({
+            refetchInterval: 1000,
+          }),
+        ],
+      },
+      {
+        query: spy,
+        key: ['key'],
+        refetchInterval: 1000,
+      },
+    )
+
+    // Initial fetch
+    await flushPromises()
+    expect(spy).toHaveBeenCalledTimes(1)
+
+    // Wait for 500ms (half the interval)
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+
+    // Trigger manual refetch
+    wrapper.vm.refetch()
+    await flushPromises()
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    // Wait for full original interval (another 500ms)
+    vi.advanceTimersByTime(500)
+    await flushPromises()
+    // Should not have refetched because original interval should be cleared
+    expect(spy).toHaveBeenCalledTimes(2)
+
+    // Wait for full new interval (1000ms)
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    // Should have refetched once from the new interval
+    expect(spy).toHaveBeenCalledTimes(3)
+
+    // Wait for another full interval
+    vi.advanceTimersByTime(1000)
+    await flushPromises()
+    // Should have refetched again, proving only one interval is running
+    expect(spy).toHaveBeenCalledTimes(4)
+
+    wrapper.unmount()
+  })
+
+  describe('focus behavior', () => {
+    let visibilityState = 'visible'
+    let visibilityChangeCallbacks: Array<() => void> = []
+
+    beforeEach(() => {
+      visibilityState = 'visible'
+
+      // Mock document visibility API
+      Object.defineProperty(document, 'visibilityState', {
+        configurable: true,
+        get: () => visibilityState,
+      })
+      document.addEventListener = vi.fn((event, callback) => {
+        if (event === 'visibilitychange') {
+          visibilityChangeCallbacks.push(callback)
+        }
+      })
+      document.removeEventListener = vi.fn((event, callback) => {
+        if (event === 'visibilitychange') {
+          visibilityChangeCallbacks = visibilityChangeCallbacks.filter((cb) => cb !== callback)
+        }
+      })
+    })
+
+    afterEach(() => {
+      visibilityChangeCallbacks = []
+      vi.clearAllMocks()
+    })
+
+    it('should not refetch when tab is not focused and refetchIntervalInBackground is false', async () => {
+      const spy = vi.fn(async () => 42)
+      const { wrapper } = factory(
+        {
+          plugins: [PiniaColadaRefetchInterval()],
+        },
+        {
+          query: spy,
+          key: ['key'],
+          refetchInterval: 1000,
+          refetchIntervalInBackground: false,
+        },
+      )
+
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab losing focus
+      visibilityState = 'hidden'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should not have refetched
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+    })
+
+    it('should refetch when tab is not focused but refetchIntervalInBackground is true', async () => {
+      const spy = vi.fn(async () => 42)
+      const { wrapper } = factory(
+        {
+          plugins: [PiniaColadaRefetchInterval()],
+        },
+        {
+          query: spy,
+          key: ['key'],
+          refetchInterval: 1000,
+          refetchIntervalInBackground: true,
+        },
+      )
+
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab losing focus
+      visibilityState = 'hidden'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should have refetched because refetchIntervalInBackground is true
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      wrapper.unmount()
+    })
+
+    it('should immediately resume refetching when tab regains focus', async () => {
+      const spy = vi.fn(async () => 42)
+      const { wrapper } = factory(
+        {
+          plugins: [PiniaColadaRefetchInterval()],
+        },
+        {
+          query: spy,
+          key: ['key'],
+          refetchInterval: 1000,
+          refetchIntervalInBackground: false,
+        },
+      )
+
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab losing focus
+      visibilityState = 'hidden'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should not have refetched while hidden
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab regaining focus
+      visibilityState = 'visible'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Should have refetched after regaining focus
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should continue refetching
+      expect(spy).toHaveBeenCalledTimes(3)
+
+      wrapper.unmount()
+    })
+
+    it('should not resume refetching when tab regains focus if refetchOnWindowFocus is false', async () => {
+      const spy = vi.fn(async () => 42)
+      const { wrapper } = factory(
+        {
+          plugins: [PiniaColadaRefetchInterval()],
+        },
+        {
+          query: spy,
+          key: ['key'],
+          refetchInterval: 1000,
+          refetchIntervalInBackground: false,
+          refetchOnWindowFocus: false,
+        },
+      )
+
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab losing focus
+      visibilityState = 'hidden'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should not have refetched while hidden
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab regaining focus
+      visibilityState = 'visible'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Should have refetched after regaining focus
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should not continue refetching
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      wrapper.unmount()
+    })
+
+    it('should use global refetchIntervalInBackground option when local option is not provided', async () => {
+      const spy = vi.fn(async () => 42)
+      const { wrapper } = factory(
+        {
+          plugins: [
+            PiniaColadaRefetchInterval({
+              refetchInterval: 1000,
+              refetchIntervalInBackground: true,
+            }),
+          ],
+        },
+        {
+          query: spy,
+          key: ['key'],
+          refetchInterval: 1000,
+        },
+      )
+
+      await flushPromises()
+      expect(spy).toHaveBeenCalledTimes(1)
+
+      // Simulate tab losing focus
+      visibilityState = 'hidden'
+      visibilityChangeCallbacks.forEach((callback) => callback())
+
+      // Advance timer
+      vi.advanceTimersByTime(1000)
+      await flushPromises()
+
+      // Should have refetched because global refetchIntervalInBackground is true
+      expect(spy).toHaveBeenCalledTimes(2)
+
+      wrapper.unmount()
+    })
+  })
+})

--- a/plugins/refetch-interval/tsup.config.ts
+++ b/plugins/refetch-interval/tsup.config.ts
@@ -1,0 +1,19 @@
+import { type Options, defineConfig } from 'tsup'
+
+const commonOptions = {
+  // splitting: false,
+  sourcemap: true,
+  format: ['cjs', 'esm'],
+  external: ['vue', 'pinia', '@pinia/colada'],
+  dts: true,
+  target: 'esnext',
+} satisfies Options
+
+export default defineConfig([
+  {
+    ...commonOptions,
+    clean: true,
+    entry: ['src/index.ts'],
+    globalName: 'PiniaColadaRefetchInterval',
+  },
+])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,6 +248,12 @@ importers:
         specifier: workspace:^
         version: link:../..
 
+  plugins/refetch-interval:
+    devDependencies:
+      '@pinia/colada':
+        specifier: workspace:^
+        version: link:../..
+
   plugins/retry:
     devDependencies:
       '@pinia/colada':


### PR DESCRIPTION
Hi! Colada is awesome! I’m planning to migrate from TanStack, but the key feature I’m currently missing to start using the library is `refetchInterval`.

I’ve added a base plugin and some test cases, following the structure of other plugins. It works and behaves similarly to TanStack, but Colada’s plugin API feels a bit complicated to me, so I’d appreciate your help in finishing it properly. 

In particular, I’m unsure about the Map keys I’m using. Should we use the query key (array?) itself as the Map key? And should it be a WeakMap instead? 