### PR TITLE
fix: make options parameter optional in types

### DIFF
--- a/src/pinia-colada.ts
+++ b/src/pinia-colada.ts
@@ -29,7 +29,7 @@ export interface PiniaColadaOptions extends UseQueryOptionsGlobal {
  * @param app - Vue App
  * @param options - Pinia Colada options
  */
-export const PiniaColada: Plugin<PiniaColadaOptions> = (
+export const PiniaColada: Plugin<[PiniaColadaOptions?]> = (
   app: App,
   options: PiniaColadaOptions = {},
 ): void => {

--- a/src/query-options.test-d.ts
+++ b/src/query-options.test-d.ts
@@ -6,7 +6,6 @@ declare const app: App
 
 describe('PiniaColada types', () => {
   it('works', () => {
-    // @ts-expect-error: FIXME: can this be fixed?
     app.use(PiniaColada)
     app.use(PiniaColada, {})
   })


### PR DESCRIPTION
The types inside vue define that `Plugin<T>` where `T` isn't an array implies that the options _must_ be passed.

When you do specify a tuple/array, you're defining the parameters of the function. So `Plugin<[T0, T1]>` means `use(fn, T0, T1)`.

We can use this with an optional tuple member to make the parameter optional: `Plugin<[T?]>` (which is basically `(...params: [T?])`).