### PR TITLE
docs: use function for the query key

### DIFF
--- a/docs/guide/queries.md
+++ b/docs/guide/queries.md
@@ -135,7 +135,7 @@ export const useFilteredTodos = defineQuery(() => { // [!code ++]
   // `search` is shared by all components using this query
   const search = ref('')
   const { state, ...rest } = useQuery({
-    key: ['todos', { search: search.value }],
+    key: () => ['todos', { search: search.value }],
     query: () => fetch(`/api/todos?filter=${search.value}`, { method: 'GET' }),
   })
   return {


### PR DESCRIPTION
There seems to be a mistake in the documentation in defining the query key for the `defineQuery` example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the filtering of displayed items, ensuring that your search input now produces updated results more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->