### PR TITLE
docs: use function for dynamic keys in the hierarchical keys example

### DIFF
--- a/docs/guide/query-keys.md
+++ b/docs/guide/query-keys.md
@@ -74,12 +74,12 @@ One of the most powerful features of query keys is that they are hierarchical. T
 ```ts
 // gets the product with all its details
 useQuery({
-  key: () => ['products', productId],
-  query: () => getProductById(productId),
+  key: () => ['products', productId.value],
+  query: () => getProductById(productId.value),
 })
 useQuery({
-  key: () => ['products', productId, { searchResult: true }],
-  query: () => getProductSummaryById(productId),
+  key: () => ['products', productId.value, { searchResult: true }],
+  query: () => getProductSummaryById(productId.value),
 })
 ```
 

--- a/docs/guide/query-keys.md
+++ b/docs/guide/query-keys.md
@@ -74,11 +74,11 @@ One of the most powerful features of query keys is that they are hierarchical. T
 ```ts
 // gets the product with all its details
 useQuery({
-  key: ['products', productId],
+  key: () => ['products', productId],
   query: () => getProductById(productId),
 })
 useQuery({
-  key: ['products', productId, { searchResult: true }],
+  key: () => ['products', productId, { searchResult: true }],
   query: () => getProductSummaryById(productId),
 })
 ```


### PR DESCRIPTION
It's similar to #226. The same mistake exists in the [hierarchical keys](https://pinia-colada.esm.dev/guide/query-keys.html#Keys-are-hierarchical) example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated query examples to showcase a more dynamic approach for generating cache keys, enhancing clarity and consistency in our documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->