### PR TITLE
docs: mention retry plugin in tvq migration guide

### DIFF
--- a/docs/cookbook/migration-tvq.md
+++ b/docs/cookbook/migration-tvq.md
@@ -34,6 +34,7 @@ Most of the sensible defaults from `@tanstack/vue-query` are kept in `@pinia/col
 | `refetch({ throwOnError: true })`   | `refetch(true)`                 | Same for `refresh()`                                                                                                                                                  |
 | `useQuery({ select })`              | none                            | Use a `computed()` or write the logic within `query` instead. [See this discussion](https://github.com/posva/pinia-colada/discussions/113#discussioncomment-11311927) |
 | `useQuery({ refetchInterval })`     | Auto Refetch plugin             | Use the [`@pinia/colada-plugin-auto-refetch`](https://github.com/posva/pinia-colada/tree/main/plugins/auto-refetch)                                                   |
+| `useQuery({ retry })`               | Retry plugin                    | Use the [`@pinia/colada-plugin-retry`](https://github.com/posva/pinia-colada/tree/main/plugins/retry)                                                                 |
 | `useQuery().dataUpdatedAt`          | Custom plugin or component code | [Custom plugin](../advanced/plugins.md#Adding-a-dataUpdatedAt-property-to-queries)                                                                                    |
 
 ### Using `ref` and `computed` in `queryKey`


### PR DESCRIPTION
I used the retry plugin when migrating from TanStack Query to Pinia Colada. Mentioning this difference in the migration guide might be helpful.

Additionally, I would like to write some test cases for the retry plugin. Would it be okay to submit a PR for that? Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Enhanced the migration guide with updated instructions on implementing retry functionality. Users now receive guidance on leveraging a dedicated plugin to enable reliable retry logic during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->