### PR TITLE
feat: add ResizablePanel component

### DIFF
--- a/devtools/components.d.ts
+++ b/devtools/components.d.ts
@@ -24,6 +24,7 @@ declare module 'vue' {
     ILucideXOctagon: typeof import('~icons/lucide/x-octagon')['default']
     ListQueryEntry: typeof import('./src/panel/components/ListQueryEntry.vue')['default']
     PiPContainer: typeof import('./src/panel/components/PiPContainer.vue')['default']
+    ResizablePanel: typeof import('./src/panel/components/ResizablePanel.vue')['default']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
     UButton: typeof import('./src/panel/components/UButton.ce.vue')['default']

--- a/devtools/src/panel/DevtoolsPanel.ce.vue
+++ b/devtools/src/panel/DevtoolsPanel.ce.vue
@@ -3,6 +3,8 @@ import { ref, watch, onMounted, onUnmounted, provide } from 'vue'
 import type { UseQueryEntryPayload, DevtoolsEmits, AppEmits } from '@pinia/colada-devtools/shared'
 import { DuplexChannel } from '@pinia/colada-devtools/shared'
 import { DUPLEX_CHANNEL_KEY, QUERIES_KEY } from './composables/duplex-channel'
+import ResizablePanel from './components/ResizablePanel.vue'
+
 
 const { port, isPip } = defineProps<{
   port: MessagePort
@@ -63,6 +65,8 @@ channel.on('queries:delete', (q) => {
 
 <template>
   <PiPContainer id="root" :is-pip>
+    <!-- How to wrap ResizePanel around PiPContainer? -->
+   <ResizablePanel>
     <main class="w-full h-full grid grid-rows-[auto_1fr] bg-ui-bg text-ui-text font-sans">
       <!-- Merged Header with Tabs Navigation -->
       <div class="flex items-center border-b border-(--ui-border) select-none">
@@ -106,6 +110,7 @@ channel.on('queries:delete', (q) => {
 
       <RouterView />
     </main>
+    </ResizablePanel>
   </PiPContainer>
 </template>
 

--- a/devtools/src/panel/components/ResizablePanel.vue
+++ b/devtools/src/panel/components/ResizablePanel.vue
@@ -1,0 +1,83 @@
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue'
+import { useResizeObserver } from '@vueuse/core'
+
+const convertRemToPixels = (rem: number) => {
+  return rem * Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
+}
+
+const isResizing = ref(false)
+const panelRef = ref<HTMLElement | null>(null)
+const panelRefWidth = ref(0)
+const panelHeight = ref('450px')
+const position = 'bottom'
+
+const handleDragStart = (event: MouseEvent) => {
+  const currentTarget = event.currentTarget as HTMLElement
+  const panelElement = currentTarget.parentElement
+  if (!panelElement) return
+
+  isResizing.value = true
+  const { height } = panelElement.getBoundingClientRect()
+  const startY = event.clientY
+  let newSize = 0
+  const minHeight = convertRemToPixels(3.5)
+
+  const runDrag = (moveEvent: MouseEvent) => {
+    moveEvent.preventDefault()
+
+      const valToAdd = startY - moveEvent.clientY
+      newSize = Math.round(height + valToAdd)
+      if (newSize < minHeight) {
+        newSize = minHeight
+      }
+
+      panelHeight.value = `${newSize}px`
+  }
+
+  const unsubscribe = () => {
+    if (isResizing.value) {
+      isResizing.value = false
+    }
+    document.removeEventListener('mousemove', runDrag, false)
+    document.removeEventListener('mouseup', unsubscribe, false)
+  }
+
+  document.addEventListener('mousemove', runDrag, false)
+  document.addEventListener('mouseup', unsubscribe, false)
+}
+
+onMounted(() => {
+  useResizeObserver(panelRef, (entries) => {
+    const entry = entries[0]
+    if (!entry) return
+
+    const { width } = entry.contentRect
+    panelRefWidth.value = width
+  })
+})
+</script>
+
+<template>
+  <div
+    ref="panelRef"
+    class="blabla fixed left-0 right-0 p-4 shadow-lg rounded-lg bg-gray-900   z-50 overflow-auto"
+    :style="{
+      height: panelHeight,
+      width: '100vw',
+      top: 'auto',
+      bottom: position === 'bottom' ? '0' : 'auto',
+    }"
+    aria-label="Pinia colada devtools"
+  >
+    <div
+      class="absolute w-full h-4 cursor-move bg-gray-200 dark:bg-gray-700 hover:bg-gray-300 dark:hover:bg-gray-600 rounded-t-lg top-0 left-0"
+      @mousedown="handleDragStart"
+    />
+
+    <div class="mt-6 pt-2">
+      <slot />
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
This PR adds a reusable ResizablePanel component that currently supports vertical resizing.

There’s also an issue with wrapping the PipContainer inside the component. Wrapping the main content works fine, but the PipContainer isn’t behaving as expected and is left hanging in the background.

What’s done so far:

Basic ResizablePanel component is set up.
Vertical resizing works when wrapping any component except PipContainer.

What’s next:
Figure out how to properly wrap the PipContainer.
If needed, add support for horizontal resizing.