### PR TITLE
feat(ui): control orientation of query splitpanes on small screens

### DIFF
--- a/devtools/src/panel/pages/queries.vue
+++ b/devtools/src/panel/pages/queries.vue
@@ -5,6 +5,9 @@ import { useQueryEntries } from '../composables/duplex-channel'
 import { getQueryStatus, STATUS_COLOR_CLASSES } from '../utils/query-state'
 import type { UseQueryEntryPayloadStatus } from '../utils/query-state'
 import type { UseQueryEntryPayload } from '@pinia/colada-devtools/shared'
+import { useWindowSize } from '@vueuse/core'
+
+const { width: screenWidth } = useWindowSize()
 
 const searchQuery = ref('')
 
@@ -81,7 +84,7 @@ const queriesGrouped = computed<
       </div>
     </div>
 
-    <Splitpanes class="overflow-hidden">
+    <Splitpanes class="overflow-hidden" :horizontal="screenWidth < 800">
       <!-- List Panel -->
       <Pane min-size="15" :size="30" class="flex flex-col">
         <ol role="list" class="divide-y divide-(--ui-border)">


### PR DESCRIPTION
Change orientation of query splitpanes below 800px

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The layout of split panes now automatically adjusts orientation based on screen width, providing a horizontal split on smaller screens and a vertical split on larger screens for improved responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->