### PR TITLE
docs: remove the unused word `vue`

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -61,7 +61,7 @@ import { PiniaColadaDevtools } from '@pinia/colada-devtools'
   </main>
 
   <PiniaColadaDevtools  />
-</template>vue
+</template>
 ```
 
 ### Keeping devtools in production


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Fixed a minor syntax error in the Vue template closing tag within the installation guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->