### PR TITLE
docs: update `invalidateQueries` behavior description

### DIFF
--- a/docs/guide/query-invalidation.md
+++ b/docs/guide/query-invalidation.md
@@ -18,12 +18,13 @@ queryCache.invalidateQueries({ key: ['todos'], exact: true })
 
 // Refetch all active queries
 queryCache.invalidateQueries()
-
-// Invalidate all queries, even if they are not active
-queryCache.invalidateQueries({ active: null })
 ```
 
-By default, `invalidateQueries()` applies an `{ active: true }` filter to only invalidate active queries. You can override this behavior by passing `null` to the `active` option.
+By default, `invalidateQueries()` invalidates all queries (both active and inactive) but only refetches active queries. Inactive queries are marked as stale and will be refetched when they become active again. You can change this behavior by passing a second parameter to refetch all queries:
+
+```ts
+queryCache.invalidateQueries({ key: ['todos'] }, 'all')
+```
 
 ::: info
 


### PR DESCRIPTION
Hi there,

I noticed that the query invalidation behavior has changed, so I’ve updated the documentation to reflect the changes introduced in [`0.16.0`](https://github.com/posva/pinia-colada/blob/main/CHANGELOG.md#0160-2025-05-21). Feel free to close this PR if it’s not applicable.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the default behavior of query invalidation and refetching in the documentation.
  * Updated examples to accurately reflect how to refetch all queries immediately.
  * Removed outdated information regarding invalidation options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->