### PR TITLE
docs: fix defaultError property name

### DIFF
--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -92,7 +92,7 @@ declare module '@pinia/colada' {
   interface TypesConfig {
     // This will be used as the default error type for all queries and mutations
     // instead of the built-in `Error` type
-    error: MyCustomError
+    defaultError: MyCustomError
   }
 }
 ```


### PR DESCRIPTION
Fix minor notation inconsistencies in error handling.

---

### Refs

* https://github.com/posva/pinia-colada/blob/96c6aec467c199f0534cbedcd18251f0dd3ae4b3/src/types-extension.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to reflect the renaming of a property from `error` to `defaultError` in configuration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->