### PR TITLE
docs: add `mutateAsync` usage in tvq migration guide

### DIFF
--- a/docs/cookbook/migration-tvq.md
+++ b/docs/cookbook/migration-tvq.md
@@ -49,6 +49,22 @@ useQuery({
 })
 ```
 
+### Component-specific side effects in mutations
+
+TanStack's `mutate` function allows you to define callback options to trigger component-specific side effects. In Pinia Colada, it's recommended to use `mutateAsync` to handle those effects:
+
+```ts
+mutate(todo, { // [!code --]
+  onSuccess, // [!code --]
+  onError, // [!code --]
+  onSettled, // [!code --]
+}) // [!code --]
+mutateAsync(todo) // [!code ++]
+  .then(onSuccess) // [!code ++]
+  .catch(onError) // [!code ++]
+  .finally(onSettled) // [!code ++]
+```
+
 ## Differences in philosophy
 
 These differences are a bit more subtle and span across multiple layers of the library.

--- a/docs/cookbook/migration-tvq.md
+++ b/docs/cookbook/migration-tvq.md
@@ -59,10 +59,15 @@ mutate(todo, { // [!code --]
   onError, // [!code --]
   onSettled, // [!code --]
 }) // [!code --]
-mutateAsync(todo) // [!code ++]
-  .then(onSuccess) // [!code ++]
-  .catch(onError) // [!code ++]
-  .finally(onSettled) // [!code ++]
+mutateAsync(todo)
+  .then((data) => {
+    onSuccess(data)
+    onSettled?.(data, null)
+  })
+  .catch((err) => {
+    onError(err)
+    onSettled?.(undefined, err)
+  })
 ```
 
 ## Differences in philosophy


### PR DESCRIPTION
Update the tvq migration guide to use `mutateAsync` in Pinia Colada for handling component-specific side effects, feel free to edit directly or close this if it’s not suitable.

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new section to the migration guide explaining how to handle component-specific side effects in mutations, with examples comparing TanStack and Pinia Colada approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->