### PR TITLE
fix: Add vue peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     }
   ],
   "peerDependencies": {
-    "pinia": "^2.2.6 || ^3.0.0"
+    "pinia": "^2.2.6 || ^3.0.0",
+    "vue": "^3"
   },
   "dependencies": {
     "@vue/devtools-api": "^8.0.0"
@@ -158,6 +159,7 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@ast-grep/cli",
+      "@parcel/watcher",
       "@tailwindcss/oxide",
       "esbuild",
       "simple-git-hooks"


### PR DESCRIPTION
Pinia imports vue in its public types, so for it to work correctly with more strict package managers like pnpm, it needs to be declared as a peer dependency, or pnpm might link it to the wrong version of vue in a monorepo/workspace when there are multiple versions of it used.