### PR TITLE
docs: clarify gc behavior of `setQueryData`

### DIFF
--- a/docs/cookbook/prefetching.md
+++ b/docs/cookbook/prefetching.md
@@ -36,3 +36,5 @@ queryCache.setQueryData(
   await fetch('/api/users').then((res) => res.json()),
 )
 ```
+
+When query data is added to the cache but not actively used (e.g. by a component via `useQuery`), it will be garbage collected after the `gcTime`, which defaults to five minutes.


### PR DESCRIPTION
Added a note about GC behavior in `setQueryData`. I'm not sure it's necessary, so feel free to close if it's not needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to clarify how unused cached query data is automatically removed after a configurable period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->