### PR TITLE
feat: add ssrPrefetch query-option

### DIFF
--- a/src/query-options.ts
+++ b/src/query-options.ts
@@ -68,6 +68,12 @@ export interface UseQueryOptionsGlobal {
    * @default false
    */
   ssrCatchError?: boolean
+
+  /**
+   * Wherher to prefetch the query during SSR
+   * @default true
+   */
+  ssrPrefetch?: boolean
 }
 
 /**
@@ -112,6 +118,7 @@ export interface UseQueryOptions<
     | 'refetchOnWindowFocus'
     | 'staleTime'
     | 'ssrCatchError'
+    | 'ssrPrefetch'
   > {
   /**
    * The key used to identify the query. Array of primitives **without**
@@ -176,6 +183,7 @@ export const USE_QUERY_DEFAULTS = {
   refetchOnReconnect: true as NonNullable<UseQueryOptions['refetchOnReconnect']>,
   refetchOnMount: true as NonNullable<UseQueryOptions['refetchOnMount']>,
   enabled: true as MaybeRefOrGetter<boolean>,
+  ssrPrefetch: true as NonNullable<UseQueryOptions['ssrPrefetch']>,
 } satisfies UseQueryOptionsGlobal
 
 export type UseQueryOptionsWithDefaults<
@@ -197,6 +205,7 @@ export type UseQueryOptionsGlobalDefaults = Pick<
   | 'refetchOnWindowFocus'
   | 'staleTime'
   | 'ssrCatchError'
+  | 'ssrPrefetch'
 > &
   typeof USE_QUERY_DEFAULTS
 

--- a/src/ssr.spec.ts
+++ b/src/ssr.spec.ts
@@ -95,4 +95,15 @@ describe('SSR', () => {
     expect(await renderToString(app)).toMatchInlineSnapshot(`"<!---->"`)
     expect(spy).toHaveBeenCalledTimes(0)
   })
+
+  it(`Don't prefetch query when ssrPrefetch is false`, async () => {
+    const { app, query } = renderApp({
+      options: {
+        ssrPrefetch: false,
+      },
+    })
+    query.mockResolvedValue(42)
+    expect(await renderToString(app)).toMatchInlineSnapshot(`"<!---->"`)
+    expect(query).not.toHaveBeenCalled()
+  })
 })

--- a/src/use-query.ts
+++ b/src/use-query.ts
@@ -283,7 +283,7 @@ export function useQuery<
     refetch,
   } satisfies UseQueryReturn<TData, TError, TDataInitial>
 
-  if (hasCurrentInstance) {
+  if (hasCurrentInstance && options.value.ssrPrefetch) {
     // only happens on server, app awaits this
     onServerPrefetch(async () => {
       if (toValue(enabled)) await refresh(!options.value.ssrCatchError)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an SSR option to control query prefetching during server-side rendering (ssrPrefetch). Enabled by default; can be disabled per query or via global defaults.

- Tests
  - Added coverage to verify that queries are not prefetched during SSR when ssrPrefetch is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->