### PR TITLE
docs: fix magic number

### DIFF
--- a/docs/guide/query-keys.md
+++ b/docs/guide/query-keys.md
@@ -194,7 +194,7 @@ const route = useRoute()
 
 const { state } = useQuery({
   key: () => DOCUMENT_QUERY_KEYS.byId(route.params.docId),
-  query: () => getDocumentById(1),
+  query: () => getDocumentById(route.params.docId),
 })
 
 const queryCache = useQueryCache()


### PR DESCRIPTION
## Summary

Thank you for the excellent documentation! 
Found a small typo(maybe) in the query keys example where `getDocumentById(1)` should use `route.params.docId`.

https://pinia-colada.esm.dev/guide/query-keys.html#Managing-query-keys-key-factories-
