### PR TITLE
docs: fix typo

### DIFF
--- a/docs/guide/query-keys.md
+++ b/docs/guide/query-keys.md
@@ -221,7 +221,7 @@ const docList = queryCache.getQueryData<Doc[]>(['documents', 'list'])
 //
 ```
 
-While this helps with types, it's not only manual but not strict. If we define query options with `defineQueryOptions`, the _key_ will be automatically _tagged_ with type information inferred from `query`, making it easier and stricter to use:
+While this helps with types, it's not only manual but also not strict. If we define query options with `defineQueryOptions`, the _key_ will be automatically _tagged_ with type information inferred from `query`, making it easier and stricter to use:
 
 ```ts{3-6,9} twoslash
 import { useQueryCache, defineQueryOptions } from '@pinia/colada'


### PR DESCRIPTION
Love how clear the docs are overall!
Just noticed a small grammar issue while reading through the docs.

"it's not only manual but not strict." -> "it's not only manual but also not strict."