### PR TITLE
fix: `TError` inference from DefineQueryOptions and DefineQueryOptionsTagged

### DIFF
--- a/src/query-options.ts
+++ b/src/query-options.ts
@@ -114,6 +114,16 @@ export interface UseQueryOptions<
     | 'ssrCatchError'
   > {
   /**
+   * Phantom property to ensure TError generic parameter is included in the
+   * interface structure.
+   * This property should never be used directly and is only for type system
+   * correctness.
+   *
+   * @internal
+   */
+  readonly __ignore_remove_maybe_ref__terror?: TError;
+
+  /**
    * The key used to identify the query. Array of primitives **without**
    * reactive values or a reactive array or getter. It should be treaded as an
    * array of dependencies of your queries, e.g. if you use the

--- a/src/use-query.test-d.ts
+++ b/src/use-query.test-d.ts
@@ -1,6 +1,9 @@
 import { assertType, describe, expectTypeOf, it } from 'vitest'
 import type { Ref } from 'vue'
 import { useQuery } from './use-query'
+import type { UseQueryOptions } from './query-options'
+import type { DefineQueryOptions } from './define-query'
+import type { DefineQueryOptionsTagged } from './define-query-options'
 
 describe('useQuery type inference', () => {
   it('infers the data type', () => {
@@ -259,6 +262,46 @@ describe('useQuery type inference', () => {
   it('disallows passing a second argument', () => {
     // @ts-expect-error: should fail
     useQuery({ key: ['id'], query: async () => 42 }, () => ({}))
+  })
+
+  it('correctly infers TError when passed a UseQueryOptions', () => {
+    const options = {} as UseQueryOptions<unknown, MyCustomError>;
+
+    const { state, error } = useQuery(options);
+    expectTypeOf<MyCustomError | null>(error.value);
+    expectTypeOf<MyCustomError | null>(state.value.error);
+  })
+
+  it('correctly infers TError when passed a DefineQueryOptions', () => {
+    const options = {} as DefineQueryOptions<unknown, MyCustomError>;
+
+    const { state, error } = useQuery(options);
+    expectTypeOf<MyCustomError | null>(error.value);
+    expectTypeOf<MyCustomError | null>(state.value.error);
+  })
+
+  it('correctly infers TError when passed a () => DefineQueryOptions', () => {
+    const options = {} as DefineQueryOptions<unknown, MyCustomError>;
+
+    const { state, error } = useQuery(() => options);
+    expectTypeOf<MyCustomError | null>(error.value);
+    expectTypeOf<MyCustomError | null>(state.value.error);
+  })
+
+  it('correctly infers TError when passed a DefineQueryOptionsTagged', () => {
+    const options = {} as DefineQueryOptionsTagged<unknown, MyCustomError>;
+
+    const { state, error } = useQuery(options);
+    expectTypeOf<MyCustomError | null>(error.value);
+    expectTypeOf<MyCustomError | null>(state.value.error);
+  })
+
+  it('correctly infers TError when passed a () => DefineQueryOptionsTagged', () => {
+    const options = {} as DefineQueryOptionsTagged<unknown, MyCustomError>;
+
+    const { state, error } = useQuery(() => options);
+    expectTypeOf<MyCustomError | null>(error.value);
+    expectTypeOf<MyCustomError | null>(state.value.error);
   })
 })
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -216,11 +216,14 @@ export type _IsMaybeRefOrGetter<T> = [T] extends [MaybeRefOrGetter<infer U>]
 export type _UnwrapMaybeRefOrGetter<T> = T extends MaybeRefOrGetter<infer U> ? U : T
 
 /**
- * Removes the `MaybeRefOrGetter` wrapper from all fields of an object.
+ * Removes the `MaybeRefOrGetter` wrapper from all fields of an object,
+ * except for fields starting with `__ignore_remove_maybe_ref__`.
  * @internal
  */
 export type _RemoveMaybeRef<T> = {
-  [K in keyof T]: _IsMaybeRefOrGetter<NonNullable<T[K]>> extends true
-    ? _UnwrapMaybeRefOrGetter<T[K]>
-    : T[K]
-}
+  [K in keyof T]: K extends `__ignore_remove_maybe_ref__${string}`
+    ? T[K]
+    : _IsMaybeRefOrGetter<NonNullable<T[K]>> extends true
+      ? _UnwrapMaybeRefOrGetter<T[K]>
+      : T[K];
+};


### PR DESCRIPTION
Fixes #367.

Adds a readonly internal optional field to `UseQueryOptions` interface with the type of `TError` and 5 type tests for `useQuery`.

To fix some type errors I have also excluded the added field from `_RemoveMaybeRef`.
