### PR TITLE
fix: prevent internal cache store serialization

### DIFF
--- a/nuxt/src/runtime/plugin.ts
+++ b/nuxt/src/runtime/plugin.ts
@@ -23,9 +23,11 @@ export default defineNuxtPlugin({
       nuxtApp.hook('app:rendered', ({ ssrContext }) => {
         if (ssrContext) {
           ssrContext.payload.pinia_colada = markRaw(serializeQueryCache(queryCache))
+          queryCache.caches.clear()
         }
       })
-    } else if (nuxtApp.payload && nuxtApp.payload.pinia_colada) {
+    }
+    else if (nuxtApp.payload && nuxtApp.payload.pinia_colada) {
       // we are inside of an injectable context so `useQueryCache()` works
       hydrateQueryCache(queryCache, nuxtApp.payload.pinia_colada)
     }


### PR DESCRIPTION
I think the cache needs to be cleared to prevent serialization on `ssrContext.payload.pinia`, since serialization is handled manually on the `ssrContext.payload.pinia_colada` property 🤔?

* Resolves #374

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved occasional stale data after server-side rendering by clearing query cache per request.
  * Improved reliability of initial page load and hydration, reducing rare cross-request data leakage.

* **Refactor**
  * Reordered conditional logic around hydration to streamline SSR flow without changing user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->