### PR TITLE
Export `toCacheKey`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type {
   DataStateStatus,
 } from './data-state'
 
-export type { EntryKey, EntryKeyTagged, toCacheKey } from './entry-keys'
+export { type EntryKey, type EntryKeyTagged, toCacheKey } from './entry-keys'
 
 export { defineQueryOptions, type DefineQueryOptionsTagged } from './define-query-options'
 


### PR DESCRIPTION
Fixed: toCacheKey is only reexported as a type

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated the public API export structure for improved consistency in how library identifiers are made available to consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->