### PR TITLE
chore: update example comment for `onMutate` option

### DIFF
--- a/src/mutation-options.ts
+++ b/src/mutation-options.ts
@@ -143,7 +143,7 @@ export interface UseMutationOptions<
    *     console.log(foo) // bar
    *     return fetch(`/api/todos/${id}`)
    *   },
-   *   onSuccess(context) {
+   *   onSuccess(data, vars, context) {
    *     console.log(context.foo) // bar
    *   },
    * })


### PR DESCRIPTION
Hi there, I noticed that the example comment for `onMutate` was inconsistent with the current `onSuccess` parameters shown in my VS Code IntelliSense, so I’ve updated it accordingly.

<img width="333" height="298" alt="image" src="https://github.com/user-attachments/assets/775e9381-bd69-4424-b99e-4e6976631197" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated mutation option examples to reflect expanded onSuccess callback parameters, now including data and variables alongside the existing context parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->