### PR TITLE
fix: minor devtool ui on light theme

### DIFF
--- a/devtools/src/panel/components/ListMutationEntry.vue
+++ b/devtools/src/panel/components/ListMutationEntry.vue
@@ -32,7 +32,7 @@ const status = computed(() => getMutationStatus(entry))
     <div
       class="grid grid-cols-[minmax(0,auto)_1fr] grid-flow-col items-center gap-x-2 p-1 relative text-sm @container"
       :class="[
-        isActive ? 'bg-neutral-200 dark:bg-neutral-700' : 'hover:bg-(--ui-bg-elevated)',
+        isActive ? 'bg-(--ui-bg-accented)' : 'hover:bg-(--ui-bg-elevated)',
         entry.active ? '' : 'text-(--ui-text)/50',
       ]"
     >
@@ -110,7 +110,7 @@ const status = computed(() => getMutationStatus(entry))
         title="This mutation will be garbage collected"
       >
         <UCircleProgress
-          class="size-[1em] dark:text-neutral-500 text-neutral-400"
+          class="size-[1em] text-(--ui-text-muted)"
           :max="entry.options.gcTime"
           :value="entry.devtools.inactiveAt + entry.options.gcTime - now"
         />

--- a/devtools/src/panel/components/ListQueryEntry.vue
+++ b/devtools/src/panel/components/ListQueryEntry.vue
@@ -33,7 +33,7 @@ const status = computed(() => getQueryStatus(entry))
     <div
       class="grid grid-cols-[minmax(0,auto)_1fr] grid-flow-col items-center gap-x-2 p-1 relative text-sm @container"
       :class="[
-        isActive ? 'bg-neutral-200 dark:bg-neutral-700' : 'hover:bg-(--ui-bg-elevated)',
+        isActive ? 'bg-(--ui-bg-accented)' : 'hover:bg-(--ui-bg-elevated)',
         entry.active ? '' : 'text-(--ui-text)/50',
       ]"
     >
@@ -95,7 +95,7 @@ const status = computed(() => getQueryStatus(entry))
         title="This query will be garbage collected"
       >
         <UCircleProgress
-          class="size-[1em] dark:text-neutral-500 text-neutral-400"
+          class="size-[1em] text-(--ui-text-muted)"
           :max="entry.options.gcTime"
           :value="entry.devtools.inactiveAt + entry.options.gcTime - now"
         />

--- a/devtools/src/panel/components/UCollapse.ce.vue
+++ b/devtools/src/panel/components/UCollapse.ce.vue
@@ -26,7 +26,7 @@ function scrollIfNeeded(event: TransitionEvent) {
 <template>
   <div class="collapse collapse-arrow">
     <input v-model="open" type="checkbox" />
-    <div class="collapse-title px-2 py-0.5 bg-neutral-200 dark:bg-neutral-800 theme-neutral">
+    <div class="collapse-title px-2 py-0.5 bg-(--ui-bg-muted) theme-neutral">
       <slot name="title" :open :title>
         <h3 class="font-semibold text-sm flex gap-x-1 items-center">
           <slot name="icon">


### PR DESCRIPTION
Closes #444 

For some reason the dark:bg-... variant will always be applied regardless of the light or dark theme. So I use the nuxt ui colors instead.

Previous:

<img width="1719" height="400" alt="Screenshot 2025-12-18 at 13 43 48" src="https://github.com/user-attachments/assets/79288d6e-ec30-4d9a-bb57-3a4e1e2418be" />
<img width="1720" height="399" alt="Screenshot 2025-12-18 at 13 43 33" src="https://github.com/user-attachments/assets/8298221f-5163-49e6-9474-c4b60f91a643" />

---

Now:
<img width="1719" height="399" alt="Screenshot 2025-12-18 at 13 53 52" src="https://github.com/user-attachments/assets/e6605c43-c2dc-45cd-93c2-18b9e86e2418" />
<img width="1721" height="400" alt="Screenshot 2025-12-18 at 13 54 09" src="https://github.com/user-attachments/assets/02bface9-4824-41c8-a080-d5f7fc2a8514" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated devtools panel styling to use a more consistent design language.
  * Active list item backgrounds now use themed accent colors instead of neutral colors.
  * Progress indicator colors updated to muted text color for improved visual consistency.
  * Collapse header backgrounds updated to use muted UI background styling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->