### PR TITLE
refactor: distinguish refetch and invalidate behavior in devtools

### DIFF
--- a/devtools/src/PiniaColadaDevtools.vue
+++ b/devtools/src/PiniaColadaDevtools.vue
@@ -120,7 +120,7 @@ watch(
 )
 
 transmitter.on('queries:refetch', (key) => {
-  queryCache.invalidateQueries({ key, exact: true, active: null, stale: null })
+  queryCache.invalidateQueries({ key, exact: true }, 'all')
 })
 
 transmitter.on('queries:invalidate', (key) => {


### PR DESCRIPTION
Currently, `queries:refetch` and `queries:invalidate` behave identically:

- Both invalidate all matched queries (active and inactive)
- Both trigger refetches only for active queries

This change aims to distinguish `queries:refetch` by making it refetch matched queries, including inactive ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query cache invalidation behavior in DevTools. The invalidation scope has been updated to ensure more accurate cache handling during refetch operations, potentially resolving issues where incorrect cached queries were being invalidated.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->