### PR TITLE
 docs(infinite-query): update paginated queries example

### DIFF
--- a/docs/guide/paginated-queries.md
+++ b/docs/guide/paginated-queries.md
@@ -62,7 +62,6 @@ const {
   data: facts,
   loadNextPage,
   asyncStatus,
-  isDelaying,
   hasNextPage,
 } = useInfiniteQuery({
   key: ['feed'],
@@ -96,7 +95,7 @@ watch(loadMoreEl, (el) => {
 
 <template>
   <div>
-    <button :disabled="asyncStatus === 'loading' || isDelaying" @click="loadNextPage()">
+    <button :disabled="asyncStatus === 'loading'" @click="loadNextPage()">
       Load more (or scroll down)
     </button>
     <template v-if="facts?.pages">

--- a/playground/src/pages/cat-facts.vue
+++ b/playground/src/pages/cat-facts.vue
@@ -8,7 +8,6 @@ const {
   data: facts,
   loadNextPage,
   asyncStatus,
-  isDelaying,
   hasNextPage,
 } = useInfiniteQuery({
   key: ['feed'],
@@ -42,7 +41,7 @@ watch(loadMoreEl, (el) => {
 
 <template>
   <div>
-    <button :disabled="asyncStatus === 'loading' || isDelaying" @click="loadNextPage()">
+    <button :disabled="asyncStatus === 'loading'" @click="loadNextPage()">
       Load more (or scroll down)
     </button>
     <template v-if="facts?.pages">


### PR DESCRIPTION
closes https://github.com/posva/pinia-colada/issues/475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pagination guide and examples to reflect the new infinite-query API (data/pages, hasNextPage, pageParam, initialPageParam, getNextPageParam).

* **Refactor**
  * Renamed public fields: state → data, loadMore → loadNextPage; templates now iterate per-page (pages → page.data) and use hasNextPage for loading indicators.
  * Intersection/scroll triggers and button clicks now call loadNextPage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->