### PR TITLE
feat: recentlySuccessful

### DIFF
--- a/docs/guide/mutations.md
+++ b/docs/guide/mutations.md
@@ -165,6 +165,48 @@ Most of the time, using `mutate` should be easier to use as it catches any error
 
 The mutation returns similar properties to queries, like `state`, `data`, `error`, `status`, `asyncStatus`, etc. However, mutations are, by default, not global.
 
+In addition, mutations expose a `recentlySuccessful` flag that becomes `true` right after a successful mutation and automatically flips back to `false` after a short delay. This is useful for temporary success messages (similar to Inertia’s `recentlySuccessful`).
+
+```vue
+<script setup lang="ts">
+import { useMutation } from '@pinia/colada'
+
+const { mutate, recentlySuccessful } = useMutation({
+  mutation: async () => {
+    // ...
+  },
+})
+</script>
+
+<template>
+  <button @click="mutate">Save</button>
+  <span v-if="recentlySuccessful">Saved!</span>
+</template>
+```
+
+You can configure the duration globally via the `PiniaColada` plugin, and override it per mutation. Per-mutation values take precedence.
+
+```ts
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+
+const app = createApp({})
+app.use(createPinia())
+app.use(PiniaColada, {
+  recentlySuccessfulDuration: 3000,
+})
+```
+
+```ts
+useMutation({
+  recentlySuccessfulDuration: 500,
+  mutation: async () => {
+    // ...
+  },
+})
+```
+
 ## Hooks
 
 ### Global hooks

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -28,6 +28,8 @@ app.use(PiniaColada, {
     // change the stale time for all queries to 0ms
     staleTime: 0,
   },
+  // duration for the mutation recentlySuccessful flag (ms)
+  recentlySuccessfulDuration: 2000,
   mutationOptions: {
     // add global mutation options here
   },

--- a/src/mutation-options.ts
+++ b/src/mutation-options.ts
@@ -96,6 +96,13 @@ export interface UseMutationOptionsGlobal {
    * @default 60_000 (1 minute)
    */
   gcTime?: number | false
+
+  /**
+   * Time in ms to keep `recentlySuccessful` as `true` after a successful mutation.
+   *
+   * @default 2000
+   */
+  recentlySuccessfulDuration?: number
 }
 
 /**
@@ -103,6 +110,7 @@ export interface UseMutationOptionsGlobal {
  */
 export const USE_MUTATION_DEFAULTS = {
   gcTime: (1000 * 60) as NonNullable<UseMutationOptions['gcTime']>, // 1 minute
+  recentlySuccessfulDuration: 2000,
 } satisfies UseMutationOptionsGlobal
 
 export type UseMutationOptionsWithDefaults<
@@ -120,7 +128,7 @@ export interface UseMutationOptions<
   TVars = void,
   TError = ErrorDefault,
   TContext extends Record<any, any> = _EmptyObject,
-> extends Pick<UseMutationOptionsGlobal, 'gcTime'> {
+> extends Pick<UseMutationOptionsGlobal, 'gcTime' | 'recentlySuccessfulDuration'> {
   /**
    * The key of the mutation. If the mutation is successful, it will invalidate the mutation with the same key and refetch it
    */

--- a/src/pinia-colada.ts
+++ b/src/pinia-colada.ts
@@ -30,6 +30,14 @@ export interface PiniaColadaOptions {
    * Global options for mutations. These will apply to all `useMutation()`, `defineMutation()`, etc.
    */
   mutationOptions?: UseMutationOptionsGlobal
+
+  /**
+   * Time in ms to keep `recentlySuccessful` as `true` after a successful mutation.
+   * Can be overridden per-mutation in `useMutation()`.
+   *
+   * @default 2000
+   */
+  recentlySuccessfulDuration?: number
 }
 
 /**
@@ -49,6 +57,7 @@ export const PiniaColada: Plugin<[options?: PiniaColadaOptions]> = (
     plugins,
     queryOptions,
     mutationOptions,
+    recentlySuccessfulDuration,
   } = options
 
   app.provide(USE_QUERY_OPTIONS_KEY, {
@@ -59,6 +68,7 @@ export const PiniaColada: Plugin<[options?: PiniaColadaOptions]> = (
   app.provide(USE_MUTATION_OPTIONS_KEY, {
     ...USE_MUTATION_DEFAULTS,
     ...mutationOptions,
+    ...(recentlySuccessfulDuration != null ? { recentlySuccessfulDuration } : null),
   })
 
   if (process.env.NODE_ENV !== 'production' && !pinia) {

--- a/src/use-mutation.test-d.ts
+++ b/src/use-mutation.test-d.ts
@@ -40,6 +40,14 @@ describe('useMutation type inference', () => {
     })
   })
 
+  it('exposes recentlySuccessful', () => {
+    const { recentlySuccessful } = useMutation({
+      mutation: () => Promise.resolve(42),
+    })
+
+    expectTypeOf(recentlySuccessful.value).toEqualTypeOf<boolean>()
+  })
+
   it('can infer the context from sync onMutate', () => {
     useMutation({
       onMutate() {


### PR DESCRIPTION
fix https://github.com/posva/pinia-colada/issues/487


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `recentlySuccessful` flag to mutations that automatically toggles true after successful completion and resets to false after a configurable delay.
  * Perfect for displaying temporary success messages that auto-hide.
  * Configure duration globally (default 2000ms) or override per-mutation.

* **Documentation**
  * Added guide on using the new success flag feature with examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->