### PR TITLE
fix: update entry options on ensure early return

### DIFF
--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -526,6 +526,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       // because of the immediate watcher in useQuery, the `ensure()` action is called twice on mount
       // we return early to avoid pushing to currentDefineQueryEntry
       if (previousEntry && keyHash === previousEntry.keyHash) {
+        previousEntry.options = options
         return previousEntry
       }
 

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -2094,6 +2094,38 @@ describe('useQuery', () => {
       w0.unmount()
       w1.unmount()
     })
+
+    it('should refetch after invalidateQueries when enabled changed from false to true', async () => {
+      const open = ref(false)
+      const pinia = createPinia()
+      const query = vi.fn(async () => 42)
+
+      mount(
+        defineComponent({
+          render: () => null,
+          setup() {
+            useQuery(() => ({
+              key: ['key'],
+              query,
+              enabled: open.value,
+            }))
+          },
+        }),
+        { global: { plugins: [pinia, PiniaColada] } },
+      )
+      const queryCache = useQueryCache(pinia)
+
+      await flushPromises()
+      expect(query).not.toHaveBeenCalled()
+
+      open.value = true
+      await nextTick()
+      await flushPromises()
+      expect(query).toHaveBeenCalledTimes(1)
+
+      await queryCache.invalidateQueries({ key: ['key'] })
+      expect(query).toHaveBeenCalledTimes(2)
+    })
   })
 
   it('should not create entries while unmounting', async () => {


### PR DESCRIPTION
fixes https://github.com/posva/pinia-colada/issues/536

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where query options were not properly refreshed when reusing previously cached entries with matching keys, ensuring configurations remain consistent during query invalidation and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->