### PR TITLE
feat: add `meta` support to mutations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ export {
 
 export type { PiniaColadaPlugin, PiniaColadaPluginContext } from './plugins'
 
-export type { TypesConfig } from './types-extension'
+export type { TypesConfig, QueryMeta, MutationMeta } from './types-extension'
 
 // internals
 export type {

--- a/src/mutation-options.ts
+++ b/src/mutation-options.ts
@@ -1,6 +1,6 @@
 import { inject } from 'vue'
 import type { InjectionKey } from 'vue'
-import type { ErrorDefault } from './types-extension'
+import type { ErrorDefault, MutationMeta } from './types-extension'
 import type { _ReduceContext, _MutationKey, UseMutationGlobalContext } from './use-mutation'
 import type { _EmptyObject, _Awaitable } from './utils'
 
@@ -132,6 +132,12 @@ export interface UseMutationOptions<
    * elsewhere, you should ignore this option.
    */
   key?: _MutationKey<NoInfer<TVars>>
+
+  /**
+   * Meta information associated with the mutation. Can be used by plugins
+   * to store additional data alongside the mutation entry.
+   */
+  meta?: MutationMeta
 
   /**
    * Runs before the mutation is executed. **It should be placed before `mutation()` for `context` to be inferred**. It

--- a/src/mutation-store.ts
+++ b/src/mutation-store.ts
@@ -10,6 +10,7 @@ import type { _ReduceContext } from './use-mutation'
 import { useMutationOptions } from './mutation-options'
 import type { UseMutationOptions, UseMutationOptionsWithDefaults } from './mutation-options'
 import type { EntryKey } from './entry-keys'
+import type { MutationMeta } from './types-extension'
 
 /**
  * Allows defining extensions to the mutation entry that are returned by `useMutation()`.
@@ -59,6 +60,11 @@ export interface UseMutationEntry<
    * Can be `undefined` if the entry has no key.
    */
   key: EntryKey | undefined
+
+  /**
+   * Resolved meta information for this mutation.
+   */
+  meta: MutationMeta
 
   /**
    * The variables used to call the mutation.
@@ -192,6 +198,7 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
             when: 0,
             vars,
             key,
+            meta: options.meta ?? {},
             options,
             // eslint-disable-next-line ts/ban-ts-comment
             // @ts-ignore: some plugins are adding properties to the entry type

--- a/src/types-extension.ts
+++ b/src/types-extension.ts
@@ -33,5 +33,9 @@ export type ErrorDefault = TypesConfig extends Record<'defaultError', infer E> ?
 export type QueryMeta =
   TypesConfig extends Record<'queryMeta', infer M> ? M : Record<string, unknown>
 
-// TODO:
-// export type MutationMeta = TypesConfig extends Record<'mutationMeta', infer M>
+/**
+ * The meta information stored alongside each mutation inferred from the {@link TypesConfig}.
+ * @internal
+ */
+export type MutationMeta =
+  TypesConfig extends Record<'mutationMeta', infer M> ? M : Record<string, unknown>

--- a/src/use-mutation.spec.ts
+++ b/src/use-mutation.spec.ts
@@ -674,4 +674,37 @@ describe('useMutation', () => {
       expect(remainingEntries[0]!.id).not.toBe(firstEntryId)
     })
   })
+
+  describe('meta', () => {
+    it('accepts a raw meta object', async () => {
+      const meta = { priority: 'high', cache: true }
+      const { wrapper } = mountSimple({
+        key: ['meta-test'],
+        meta,
+      })
+      const cache = useMutationCache()
+
+      wrapper.vm.mutate()
+      await flushPromises()
+
+      const entry = cache.getEntries({ key: ['meta-test'] }).at(0)!
+      expect(entry).toBeDefined()
+      expect(entry.meta).toEqual(meta)
+      expect(entry.options.meta).toBe(meta)
+    })
+
+    it('defaults to empty object when meta is not provided', async () => {
+      const { wrapper } = mountSimple({
+        key: ['no-meta'],
+      })
+      const cache = useMutationCache()
+
+      wrapper.vm.mutate()
+      await flushPromises()
+
+      const entry = cache.getEntries({ key: ['no-meta'] }).at(0)!
+      expect(entry).toBeDefined()
+      expect(entry.meta).toEqual({})
+    })
+  })
 })


### PR DESCRIPTION
## Summary
- Adds `MutationMeta` type (mirrors `QueryMeta`, extensible via `TypesConfig['mutationMeta']`)
- Adds `meta?: MutationMeta` option to `UseMutationOptions`
- Adds `meta: MutationMeta` property to `UseMutationEntry`, populated in `create()` (defaults to `{}`)
- Exports both `QueryMeta` and `MutationMeta` from the public API

## Test plan
- [x] Added tests for raw meta object on mutations
- [x] Added test for default empty object when meta is not provided
- [x] All 34 mutation tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added mutation metadata support: users can now pass an optional `meta` field when creating mutations to attach custom metadata for per-mutation tracking and configuration.
  * Exported `MutationMeta` type for TypeScript consumers.

* **Tests**
  * Added test coverage for mutation metadata functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->