### PR TITLE
fix: avoid aborting settled queries during garbage collection

### DIFF
--- a/src/query-store.spec.ts
+++ b/src/query-store.spec.ts
@@ -317,26 +317,15 @@ describe('Query Cache store', () => {
       gcTime: 1000,
     })
 
-    // Start tracking the query (simulate component mount)
-    const effect = {} as any
-    queryCache.track(entry, effect)
-
-    // Trigger the query and wait for it to resolve
+    // No tracking — deps.size stays 0, so setEntryState → scheduleGarbageCollection
+    // will enter the abort path when the query resolves in .then() (before .finally()
+    // clears entry.pending)
     const promise = queryCache.refresh(entry)
     await flushPromises()
-
-    // At this point the query has resolved (asyncStatus will transition to idle in .finally())
-    // but entry.pending is still set because .finally() hasn't run yet
-
-    // Simulate component unmount - this triggers GC
-    queryCache.untrack(entry, effect)
-    await nextTick()
+    await promise.catch(() => {})
 
     // The abort signal should NOT have been called for a settled query
     expect(abortSpy).not.toHaveBeenCalled()
-
-    // Wait for the query to fully complete
-    await promise
     expect(entry.state.value.data).toBe('data')
   })
 })

--- a/src/query-store.spec.ts
+++ b/src/query-store.spec.ts
@@ -302,4 +302,41 @@ describe('Query Cache store', () => {
     vi.advanceTimersByTime(1000)
     expect(queryCache.getEntries({ key: ['prefetch-gc'] })).toHaveLength(0)
   })
+
+  // https://github.com/posva/pinia-colada/issues/461
+  it('does not abort settled queries during garbage collection', async () => {
+    const queryCache = useQueryCache()
+    const abortSpy = vi.fn()
+
+    const entry = queryCache.ensure({
+      key: ['settled-query-gc'],
+      query: async ({ signal }) => {
+        signal.addEventListener('abort', abortSpy)
+        return 'data'
+      },
+      gcTime: 1000,
+    })
+
+    // Start tracking the query (simulate component mount)
+    const effect = {} as any
+    queryCache.track(entry, effect)
+
+    // Trigger the query and wait for it to resolve
+    const promise = queryCache.refresh(entry)
+    await flushPromises()
+
+    // At this point the query has resolved (asyncStatus will transition to idle in .finally())
+    // but entry.pending is still set because .finally() hasn't run yet
+
+    // Simulate component unmount - this triggers GC
+    queryCache.untrack(entry, effect)
+    await nextTick()
+
+    // The abort signal should NOT have been called for a settled query
+    expect(abortSpy).not.toHaveBeenCalled()
+
+    // Wait for the query to fully complete
+    await promise
+    expect(entry.state.value.data).toBe('data')
+  })
 })

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -423,7 +423,10 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
     // and we know its gcTime value
     if (entry.deps.size > 0 || !entry.options) return
     clearTimeout(entry.gcTimeout)
-    entry.pending?.abortController.abort()
+    // only abort if the query is still loading, not if it already settled
+    if (entry.asyncStatus.value === 'loading') {
+      entry.pending?.abortController.abort()
+    }
     // avoid setting a timeout with false, Infinity or NaN
     if ((Number.isFinite as (val: unknown) => val is number)(entry.options.gcTime)) {
       entry.gcTimeout = setTimeout(() => {

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -423,8 +423,10 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
     // and we know its gcTime value
     if (entry.deps.size > 0 || !entry.options) return
     clearTimeout(entry.gcTimeout)
-    // only abort if the query is still loading, not if it already settled
-    if (entry.asyncStatus.value === 'loading') {
+    // only abort if the query hasn't settled yet because entry.pending might
+    // still be set (cleared in .finally()) but the state is already
+    // success/error
+    if (entry.state.value.status === 'pending') {
       entry.pending?.abortController.abort()
     }
     // avoid setting a timeout with false, Infinity or NaN


### PR DESCRIPTION
## Summary

Fixes #461

### Problem

 is called from  (line 789) when a query resolves. At that point,  is still non-null because the  handler has not run yet. If the component has already unmounted (e.g. during route navigation),  and the function proceeds to call  on a query that already settled successfully.

This produces unexpected s, particularly visible in Nuxt apps with route-param-based query keys.

### Fix

Only abort the pending request if the query is still actively loading (). Settled queries should not have their abort controller triggered during garbage collection.

### Test plan

- [x] All 452 existing tests pass
- [x] No regressions in query-store, use-query, or plugin tests
- [ ] Manual verification with Nuxt reproduction from #461

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed queries in settled states (success, error, idle) are no longer incorrectly aborted during garbage-collection scheduling. Resolved data is preserved and unexpected cancellations are prevented.

* **Tests**
  * Added a regression test that verifies settled queries retain their data and are not cancelled during GC scheduling, preventing future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->