### PR TITLE
fix(infinite-query): guard computePageParams against missing ext refs

### DIFF
--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1582,4 +1582,31 @@ describe('useInfiniteQuery', () => {
     expect(w2.vm.data).toEqual({ pages: [[1, 2, 3]], pageParams: [0] })
     expect(w2.vm.hasNextPage).toBe(true)
   })
+
+  it('does not crash when entry ext is missing nextPageParam', async () => {
+    const pinia = createPinia()
+    const app = createApp({})
+    app.use(pinia)
+    app.use(PiniaColada)
+    const queryCache = useQueryCache(pinia)
+
+    // simulate a cache entry whose ext refs were never initialized
+    // (e.g. the plugin's scope.run() didn't execute)
+    const entry = queryCache.ensure({
+      key: ['key'],
+      query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
+      meta: { __i: true },
+    })
+    entry.ext = {} as any
+
+    // mounting should not throw
+    const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })
+
+    await flushPromises()
+
+    expect(wrapper.vm.data).toEqual({
+      pages: [[1, 2, 3]],
+      pageParams: [0],
+    })
+  })
 })

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1474,6 +1474,30 @@ describe('useInfiniteQuery', () => {
       // After everything settles, hasNextPage should remain true
       expect(wrapper.vm.hasNextPage).toBe(true)
     })
+
+    it('can set the data before using infinite queries', async () => {
+      const pinia = createPiniawithHydratedCache({
+        // '["key"]': [{ pages: [[1, 2, 3]], pageParams: [0] }, null, 0, { __i: true }],
+      })
+      const queryCache = useQueryCache(pinia)
+      queryCache.setQueryData(['key'], { pages: [[1, 2, 3]], pageParams: [0] })
+
+      const { wrapper } = mountSimple(
+        {
+          staleTime: 1000,
+          getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+            lastPageParam >= 3 ? null : lastPageParam + 1,
+        },
+        { plugins: [pinia] },
+      )
+      await flushPromises()
+
+      expect(wrapper.vm.data).toEqual({
+        pages: [[1, 2, 3]],
+        pageParams: [0],
+      })
+      expect(wrapper.vm.hasNextPage).toBe(true)
+    })
   })
 
   // https://github.com/posva/pinia-colada/issues/458
@@ -1581,32 +1605,5 @@ describe('useInfiniteQuery', () => {
     // should work without throwing
     expect(w2.vm.data).toEqual({ pages: [[1, 2, 3]], pageParams: [0] })
     expect(w2.vm.hasNextPage).toBe(true)
-  })
-
-  it('does not crash when entry ext is missing nextPageParam', async () => {
-    const pinia = createPinia()
-    const app = createApp({})
-    app.use(pinia)
-    app.use(PiniaColada)
-    const queryCache = useQueryCache(pinia)
-
-    // simulate a cache entry whose ext refs were never initialized
-    // (e.g. the plugin's scope.run() didn't execute)
-    const entry = queryCache.ensure({
-      key: ['key'],
-      query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
-      meta: { __i: true },
-    })
-    ;(entry as { ext: object }).ext = {}
-
-    // mounting should not throw
-    const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })
-
-    await flushPromises()
-
-    expect(wrapper.vm.data).toEqual({
-      pages: [[1, 2, 3]],
-      pageParams: [0],
-    })
   })
 })

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1597,7 +1597,7 @@ describe('useInfiniteQuery', () => {
       query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
       meta: { __i: true },
     })
-    entry.ext = {} as any
+    ;(entry as { ext: object }).ext = {}
 
     // mounting should not throw
     const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -418,6 +418,10 @@ export function useInfiniteQuery<
     if (!entry) return
     const lastPageParam = data?.pageParams.at(-1)
     const exts = entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>
+    // extensions might not be initialized if the plugin's scope was stopped
+    if (!exts.nextPageParam) {
+      createInfiniteQueryEntryExtensions(exts as unknown as UseInfiniteQueryExtensions<unknown>)
+    }
     exts.nextPageParam.value =
       data && data.pages.length > 0
         ? options.getNextPageParam(data.pages.at(-1)!, data.pages, lastPageParam!, data.pageParams)

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -419,7 +419,7 @@ export function useInfiniteQuery<
     const lastPageParam = data?.pageParams.at(-1)
     const exts = entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>
     // extensions might not be initialized if the plugin's scope was stopped
-    if (!exts.nextPageParam) {
+    if (!exts.nextPageParam || !exts.previousPageParam) {
       createInfiniteQueryEntryExtensions(exts as unknown as UseInfiniteQueryExtensions<unknown>)
     }
     exts.nextPageParam.value =


### PR DESCRIPTION
We're hitting `TypeError: Cannot set properties of undefined (setting 'value')` in production (Nuxt SSR app, ~55 events across 35 users on v1.0.0/v1.1.0). The crash is in `computePageParams` when `entry.ext.nextPageParam` is undefined.

#525 fixed the `$onAction` detachment, but if `scope.run()` doesn't execute for any reason (e.g. stopped EffectScope), the ext refs are never created and `computePageParams` blows up.

This adds a guard that lazily initializes the extensions using the existing `createInfiniteQueryEntryExtensions` helper when they're missing. Includes a test that reproduces the broken state and verifies recovery.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes when restoring paginated cached data missing pagination metadata, improving stability during hydration of saved data.

* **Tests**
  * Added coverage to verify preseeded paginated cache is recognized on mount and pagination state (pages/page params and next-page availability) is preserved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->