### PR TITLE
feat(infinite-query): add setInfiniteQueryData

### DIFF
--- a/src/define-infinite-query-options.test-d.ts
+++ b/src/define-infinite-query-options.test-d.ts
@@ -105,8 +105,8 @@ describe('typed infinite query keys', () => {
     })
 
     it('rejects wrong data with static options', () => {
-      // @ts-expect-error: wrong page type
       setInfiniteQueryData(queryCache, optsStatic.key, {
+        // @ts-expect-error: wrong page type
         pages: ['wrong'],
         pageParams: [0],
       })
@@ -120,8 +120,8 @@ describe('typed infinite query keys', () => {
     })
 
     it('rejects wrong data with dynamic options', () => {
-      // @ts-expect-error: wrong page type
       setInfiniteQueryData(queryCache, optsDynamic('books').key, {
+        // @ts-expect-error: wrong page type
         pages: [42],
         pageParams: [0],
       })

--- a/src/define-infinite-query-options.test-d.ts
+++ b/src/define-infinite-query-options.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { useInfiniteQuery } from './infinite-query'
 import type { UseInfiniteQueryData } from './infinite-query'
-import { useQueryCache, defineInfiniteQueryOptions } from '@pinia/colada'
+import { setInfiniteQueryData, useQueryCache, defineInfiniteQueryOptions } from '@pinia/colada'
 import type { EntryKeyTagged } from '@pinia/colada'
 import type { ErrorDefault } from './types-extension'
 
@@ -78,6 +78,64 @@ describe('typed infinite query keys', () => {
         initialPageParam: 0,
         getNextPageParam: () => null,
         meta: { hello: 'world' },
+      })
+    })
+  })
+
+  describe('setInfiniteQueryData', () => {
+    const optsStatic = defineInfiniteQueryOptions({
+      key: ['items'],
+      query: async ({ pageParam }) => ({ id: pageParam, items: [1, 2, 3] }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.id + 1,
+    })
+
+    const optsDynamic = defineInfiniteQueryOptions((category: string) => ({
+      key: ['items', category] as const,
+      query: async ({ pageParam }) => ({ id: pageParam, items: [1, 2, 3] }),
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => lastPage.id + 1,
+    }))
+
+    it('accepts correct data with static options', () => {
+      setInfiniteQueryData(queryCache, optsStatic.key, {
+        pages: [{ id: 0, items: [1, 2, 3] }],
+        pageParams: [0],
+      })
+    })
+
+    it('rejects wrong data with static options', () => {
+      // @ts-expect-error: wrong page type
+      setInfiniteQueryData(queryCache, optsStatic.key, {
+        pages: ['wrong'],
+        pageParams: [0],
+      })
+    })
+
+    it('accepts correct data with dynamic options', () => {
+      setInfiniteQueryData(queryCache, optsDynamic('books').key, {
+        pages: [{ id: 1, items: [4, 5, 6] }],
+        pageParams: [1],
+      })
+    })
+
+    it('rejects wrong data with dynamic options', () => {
+      // @ts-expect-error: wrong page type
+      setInfiniteQueryData(queryCache, optsDynamic('books').key, {
+        pages: [42],
+        pageParams: [0],
+      })
+    })
+
+    it('types updater function correctly', () => {
+      setInfiniteQueryData(queryCache, optsStatic.key, (oldData) => {
+        expectTypeOf(oldData).toEqualTypeOf<
+          UseInfiniteQueryData<{ id: number; items: number[] }, number> | undefined
+        >()
+        return {
+          pages: [{ id: 0, items: [1] }],
+          pageParams: [0],
+        }
       })
     })
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ export { useQuery, type UseQueryReturn } from './use-query'
 export { useQueryState, type UseQueryStateReturn } from './use-query-state'
 
 export {
+  setInfiniteQueryData,
   useInfiniteQuery,
   type DefineInfiniteQueryOptions,
   type UseInfiniteQueryOptions,

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -10,7 +10,7 @@ import type { Pinia } from 'pinia'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, isRef, nextTick, ref } from 'vue'
 import { isSpy, mockConsoleError, mockWarn } from '@posva/test-utils'
-import { useInfiniteQuery } from './infinite-query'
+import { setInfiniteQueryData, useInfiniteQuery } from './infinite-query'
 import { PiniaColada } from './pinia-colada'
 import {
   hydrateQueryCache,
@@ -1474,13 +1474,16 @@ describe('useInfiniteQuery', () => {
       // After everything settles, hasNextPage should remain true
       expect(wrapper.vm.hasNextPage).toBe(true)
     })
+  })
 
-    it('can set the data before using infinite queries', async () => {
-      const pinia = createPiniawithHydratedCache({
-        // '["key"]': [{ pages: [[1, 2, 3]], pageParams: [0] }, null, 0, { __i: true }],
-      })
+  describe('setInfiniteQueryData', () => {
+    it('preserves infinite query data format when set before useInfiniteQuery', async () => {
+      const pinia = createPinia()
+      const app = createApp({})
+      app.use(pinia)
       const queryCache = useQueryCache(pinia)
-      queryCache.setQueryData(['key'], { pages: [[1, 2, 3]], pageParams: [0] })
+
+      setInfiniteQueryData(queryCache, ['key'], { pages: [[1, 2, 3]], pageParams: [0] })
 
       const { wrapper } = mountSimple(
         {
@@ -1496,7 +1499,58 @@ describe('useInfiniteQuery', () => {
         pages: [[1, 2, 3]],
         pageParams: [0],
       })
+    })
+
+    it('hasNextPage works after setInfiniteQueryData', async () => {
+      const pinia = createPinia()
+      const app = createApp({})
+      app.use(pinia)
+      const queryCache = useQueryCache(pinia)
+
+      setInfiniteQueryData(queryCache, ['key'], { pages: [[1, 2, 3]], pageParams: [0] })
+
+      const { wrapper } = mountSimple(
+        {
+          staleTime: 1000,
+          getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+            lastPageParam >= 3 ? null : lastPageParam + 1,
+        },
+        { plugins: [pinia] },
+      )
+      await flushPromises()
+
       expect(wrapper.vm.hasNextPage).toBe(true)
+    })
+
+    it('supports updater function', async () => {
+      const pinia = createPinia()
+      const app = createApp({})
+      app.use(pinia)
+      const queryCache = useQueryCache(pinia)
+
+      setInfiniteQueryData(queryCache, ['key'], { pages: [[1, 2, 3]], pageParams: [0] })
+      setInfiniteQueryData(queryCache, ['key'], (old) => ({
+        pages: [...old!.pages, [4, 5, 6]],
+        pageParams: [...old!.pageParams, 1],
+      }))
+
+      const { wrapper } = mountSimple(
+        {
+          staleTime: 1000,
+          getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+            lastPageParam >= 3 ? null : lastPageParam + 1,
+        },
+        { plugins: [pinia] },
+      )
+      await flushPromises()
+
+      expect(wrapper.vm.data).toEqual({
+        pages: [
+          [1, 2, 3],
+          [4, 5, 6],
+        ],
+        pageParams: [0, 1],
+      })
     })
   })
 

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1582,4 +1582,31 @@ describe('useInfiniteQuery', () => {
     expect(w2.vm.data).toEqual({ pages: [[1, 2, 3]], pageParams: [0] })
     expect(w2.vm.hasNextPage).toBe(true)
   })
+
+  it('does not crash when entry ext is missing nextPageParam', async () => {
+    const pinia = createPinia()
+    const app = createApp({})
+    app.use(pinia)
+    app.use(PiniaColada)
+    const queryCache = useQueryCache(pinia)
+
+    // simulate a cache entry whose ext refs were never initialized
+    // (e.g. the plugin's scope.run() didn't execute)
+    const entry = queryCache.ensure({
+      key: ['key'],
+      query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
+      meta: { __i: true },
+    })
+    entry.ext = {} as any
+
+    // mounting should not throw
+    const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })
+
+    await flushPromises()
+
+    expect(wrapper.vm.data).toEqual({
+      pages: [[1, 2, 3]],
+      pageParams: [0],
+    })
+  })
 })

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1474,6 +1474,30 @@ describe('useInfiniteQuery', () => {
       // After everything settles, hasNextPage should remain true
       expect(wrapper.vm.hasNextPage).toBe(true)
     })
+
+    it('can set the data before using infinite queries', async () => {
+      const pinia = createPiniawithHydratedCache({
+        // '["key"]': [{ pages: [[1, 2, 3]], pageParams: [0] }, null, 0, { __i: true }],
+      })
+      const queryCache = useQueryCache(pinia)
+      queryCache.setQueryData(['key'], { pages: [[1, 2, 3]], pageParams: [0] })
+
+      const { wrapper } = mountSimple(
+        {
+          staleTime: 1000,
+          getNextPageParam: (_lastPage, _allPages, lastPageParam) =>
+            lastPageParam >= 3 ? null : lastPageParam + 1,
+        },
+        { plugins: [pinia] },
+      )
+      await flushPromises()
+
+      expect(wrapper.vm.data).toEqual({
+        pages: [[1, 2, 3]],
+        pageParams: [0],
+      })
+      expect(wrapper.vm.hasNextPage).toBe(true)
+    })
   })
 
   // https://github.com/posva/pinia-colada/issues/458
@@ -1581,32 +1605,5 @@ describe('useInfiniteQuery', () => {
     // should work without throwing
     expect(w2.vm.data).toEqual({ pages: [[1, 2, 3]], pageParams: [0] })
     expect(w2.vm.hasNextPage).toBe(true)
-  })
-
-  it('does not crash when entry ext is missing nextPageParam', async () => {
-    const pinia = createPinia()
-    const app = createApp({})
-    app.use(pinia)
-    app.use(PiniaColada)
-    const queryCache = useQueryCache(pinia)
-
-    // simulate a cache entry whose ext refs were never initialized
-    // (e.g. the plugin's scope.run() didn't execute)
-    const entry = queryCache.ensure({
-      key: ['key'],
-      query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
-      meta: { __i: true },
-    })
-    ;(entry as { ext: object }).ext = {}
-
-    // mounting should not throw
-    const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })
-
-    await flushPromises()
-
-    expect(wrapper.vm.data).toEqual({
-      pages: [[1, 2, 3]],
-      pageParams: [0],
-    })
   })
 })

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -1597,7 +1597,7 @@ describe('useInfiniteQuery', () => {
       query: async () => ({ pages: [[1, 2, 3]], pageParams: [0] }),
       meta: { __i: true },
     })
-    entry.ext = {} as any
+    ;(entry as { ext: object }).ext = {}
 
     // mounting should not throw
     const { wrapper } = mountSimple({ staleTime: 1000 }, { plugins: [pinia] })

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -466,6 +466,10 @@ export function useInfiniteQuery<
     >
     const lastPageParam = data?.pageParams.at(-1)
     const exts = entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>
+    // extensions might not be initialized if the plugin's scope was stopped
+    if (!exts.nextPageParam) {
+      createInfiniteQueryEntryExtensions(exts as unknown as UseInfiniteQueryExtensions<unknown>)
+    }
     exts.nextPageParam.value =
       data && data.pages.length > 0
         ? opts.getNextPageParam(data.pages.at(-1)!, data.pages, lastPageParam!, data.pageParams)

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -6,6 +6,8 @@ import type { ErrorDefault } from './types-extension'
 import { useQueryCache, type QueryCache, type UseQueryEntry } from './query-store'
 import { noop, toValueWithArgs } from './utils'
 import type { _RemoveMaybeRef } from './utils'
+import { START_EXT } from './entry-keys'
+import type { EntryKey, EntryKeyTagged } from './entry-keys'
 
 /**
  * Structure of data stored for infinite queries.
@@ -256,6 +258,45 @@ function createInfiniteQueryEntryExtensions(extensions: UseInfiniteQueryExtensio
   extensions.hasNextPage = computed(() => extensions.nextPageParam.value != null)
   extensions.previousPageParam = shallowRef<unknown | null | undefined>()
   extensions.hasPreviousPage = computed(() => extensions.previousPageParam.value != null)
+}
+
+/**
+ * Sets the data of an infinite query entry in the cache. Unlike {@link QueryCache.setQueryData | `queryCache.setQueryData()`},
+ * this function properly marks the entry as an infinite query and initializes the
+ * infinite query extensions (`hasNextPage`, `hasPreviousPage`, etc.).
+ *
+ * Use this when you need to set infinite query data before `useInfiniteQuery()` is mounted
+ * (e.g. optimistic updates from a mutation on a different page).
+ *
+ * @param queryCache - The query cache instance
+ * @param key - The key of the infinite query
+ * @param data - The data to set, or an updater function
+ */
+export function setInfiniteQueryData<TData = unknown, TError = ErrorDefault, TPageParam = unknown>(
+  queryCache: QueryCache,
+  key: EntryKeyTagged<UseInfiniteQueryData<TData, TPageParam>, TError> | EntryKey,
+  data:
+    | UseInfiniteQueryData<TData, TPageParam>
+    | ((
+        oldData: UseInfiniteQueryData<TData, TPageParam> | undefined,
+      ) => UseInfiniteQueryData<TData, TPageParam>),
+): void {
+  // Register the infinite query plugin (idempotent) so the extend action
+  // creates properly scoped computed refs for the entry
+  PiniaColadaInfiniteQueryPlugin(queryCache._s, queryCache)
+
+  // Delegate to setQueryData for entry creation, state setting, and reactivity
+  queryCache.setQueryData(key, data)
+
+  // Mark the entry as an infinite query so the plugin recognizes it
+  const entry = queryCache.get(key)!
+  entry.meta.__i = true
+
+  // Initialize extensions via the extend action if not yet done
+  if (entry.ext === START_EXT) {
+    ;(entry as { ext: object }).ext = {}
+    queryCache.extend(entry)
+  }
 }
 
 /**

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -281,22 +281,15 @@ export function setInfiniteQueryData<TData = unknown, TError = ErrorDefault, TPa
         oldData: UseInfiniteQueryData<TData, TPageParam> | undefined,
       ) => UseInfiniteQueryData<TData, TPageParam>),
 ): void {
-  // Register the infinite query plugin (idempotent) so the extend action
-  // creates properly scoped computed refs for the entry
+  // Register the infinite query plugin (idempotent) so `ensure` creates
+  // the extra properties like hasNextPage, etc
   PiniaColadaInfiniteQueryPlugin(queryCache._s, queryCache)
 
   // Delegate to setQueryData for entry creation, state setting, and reactivity
   queryCache.setQueryData(key, data)
 
   // Mark the entry as an infinite query so the plugin recognizes it
-  const entry = queryCache.get(key)!
-  entry.meta.__i = true
-
-  // Initialize extensions via the extend action if not yet done
-  if (entry.ext === START_EXT) {
-    ;(entry as { ext: object }).ext = {}
-    queryCache.extend(entry)
-  }
+  queryCache.get(key)!.meta.__i = 1
 }
 
 /**

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -467,7 +467,7 @@ export function useInfiniteQuery<
     const lastPageParam = data?.pageParams.at(-1)
     const exts = entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>
     // extensions might not be initialized if the plugin's scope was stopped
-    if (!exts.nextPageParam) {
+    if (!exts.nextPageParam || !exts.previousPageParam) {
       createInfiniteQueryEntryExtensions(exts as unknown as UseInfiniteQueryExtensions<unknown>)
     }
     exts.nextPageParam.value =

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -6,7 +6,6 @@ import type { ErrorDefault } from './types-extension'
 import { useQueryCache, type QueryCache, type UseQueryEntry } from './query-store'
 import { noop, toValueWithArgs } from './utils'
 import type { _RemoveMaybeRef } from './utils'
-import { START_EXT } from './entry-keys'
 import type { EntryKey, EntryKeyTagged } from './entry-keys'
 
 /**
@@ -500,10 +499,6 @@ export function useInfiniteQuery<
     >
     const lastPageParam = data?.pageParams.at(-1)
     const exts = entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>
-    // extensions might not be initialized if the plugin's scope was stopped
-    if (!exts.nextPageParam || !exts.previousPageParam) {
-      createInfiniteQueryEntryExtensions(exts as unknown as UseInfiniteQueryExtensions<unknown>)
-    }
     exts.nextPageParam.value =
       data && data.pages.length > 0
         ? opts.getNextPageParam(data.pages.at(-1)!, data.pages, lastPageParam!, data.pageParams)


### PR DESCRIPTION
Closes #549 

## Summary

- Adds `setInfiniteQueryData(queryCache, key, data)` to safely set infinite query data in the cache before `useInfiniteQuery()` is mounted
- Registers the infinite query plugin, marks the entry with `meta.__i`, and triggers extension initialization via the `extend` action
- Supports updater functions like `setQueryData`

Closes the issue described in #549 — calling `queryCache.setQueryData()` with infinite query shaped data before mounting `useInfiniteQuery()` crashes because the entry lacks the `__i` meta flag and infinite query extensions.

## Test plan

- [x] `setInfiniteQueryData` before `useInfiniteQuery` preserves `{ pages, pageParams }` format
- [x] `hasNextPage` is correctly computed after `setInfiniteQueryData`
- [x] Updater function works (`(old) => newData`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for pre-populating paginated query cache entries before components mount, including updater callbacks to append/merge pages.

* **Bug Fixes**
  * Hydration now recognizes pre-seeded paginated state (pages and params) and reflects it immediately on mount.

* **Tests**
  * Added tests for pre-population, immediate reflection on mount, page/param handling, computed next-page status, and updater behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->