### PR TITLE
fix: align defineMutation lifecycle with defineQuery

### DIFF
--- a/src/define-mutation.spec.ts
+++ b/src/define-mutation.spec.ts
@@ -2,10 +2,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import type { App } from 'vue'
-import { computed, createApp, defineComponent, effectScope, inject, provide, ref } from 'vue'
+import { createApp, defineComponent, inject, nextTick, provide, ref, watch } from 'vue'
 import { defineMutation } from './define-mutation'
 import { useMutation } from './use-mutation'
-import { useMutationCache } from './mutation-store'
 import { PiniaColada } from './pinia-colada'
 import { mockWarn } from '@posva/test-utils'
 
@@ -160,54 +159,12 @@ describe('defineMutation', () => {
   })
 
   describe('scope lifecycle', () => {
-    it('pauses computed effects when all consumers unmount', async () => {
-      const mutation = vi.fn(async () => 42)
+    it('pauses effects when all consumers unmount and resumes on remount', async () => {
+      const watchSpy = vi.fn()
       const useMyMutation = defineMutation(() => {
-        const { data, ...rest } = useMutation({ mutation })
-        const doubled = computed(() => (data.value ? data.value * 2 : null))
-        return { ...rest, data, doubled }
-      })
-
-      const pinia = createPinia()
-      const wrapper = mount(
-        defineComponent({
-          setup() {
-            return { ...useMyMutation() }
-          },
-          render: () => null,
-        }),
-        { global: { plugins: [pinia, PiniaColada] } },
-      )
-
-      wrapper.vm.mutate()
-      await flushPromises()
-      expect(wrapper.vm.doubled).toBe(84)
-
-      wrapper.unmount()
-
-      // after unmount, calling the composable in a new component should resume the scope
-      const w2 = mount(
-        defineComponent({
-          setup() {
-            return { ...useMyMutation() }
-          },
-          render: () => null,
-        }),
-        { global: { plugins: [pinia, PiniaColada] } },
-      )
-
-      // data is preserved from the previous mutation
-      expect(w2.vm.doubled).toBe(84)
-
-      w2.vm.mutate()
-      await flushPromises()
-      expect(w2.vm.doubled).toBe(84)
-    })
-
-    it('resumes the scope when a new consumer mounts after all unmounted', async () => {
-      const mutation = vi.fn(async () => 42)
-      const useMyMutation = defineMutation({
-        mutation,
+        const counter = ref(0)
+        watch(counter, watchSpy)
+        return { counter, ...useMutation({ mutation: async () => 42 }) }
       })
 
       const pinia = createPinia()
@@ -218,97 +175,26 @@ describe('defineMutation', () => {
         render: () => null,
       })
 
+      // mount → watch should be active
       const w1 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
-      w1.vm.mutate()
-      await flushPromises()
-      expect(w1.vm.data).toBe(42)
+      const { counter } = useMyMutation()
+      counter.value++
+      await nextTick()
+      expect(watchSpy).toHaveBeenCalledTimes(1)
 
+      // unmount all → scope paused → watch should stop
       w1.unmount()
+      watchSpy.mockClear()
+      counter.value++
+      await nextTick()
+      expect(watchSpy).toHaveBeenCalledTimes(0)
 
-      // mount a new consumer - scope should resume
-      const w2 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
-      // data from previous mutation is still accessible
-      expect(w2.vm.data).toBe(42)
-
-      // can still mutate
-      mutation.mockResolvedValueOnce(99)
-      w2.vm.mutate()
-      await flushPromises()
-      expect(w2.vm.data).toBe(99)
-    })
-  })
-
-  describe('gcTime', () => {
-    it('keeps the entry in cache while a consumer is mounted', async () => {
-      const mutation = vi.fn(async () => 42)
-      const useMyMutation = defineMutation({
-        key: ['test'],
-        mutation,
-        gcTime: 1000,
-      })
-
-      const pinia = createPinia()
-      const wrapper = mount(
-        defineComponent({
-          setup() {
-            return { ...useMyMutation() }
-          },
-          render: () => null,
-        }),
-        { global: { plugins: [pinia, PiniaColada] } },
-      )
-
-      wrapper.vm.mutate()
-      await flushPromises()
-
-      const cache = useMutationCache()
-      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
-
-      // gcTime passes but component is still mounted → entry stays
-      vi.advanceTimersByTime(2000)
-      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
-    })
-
-    it('keeps the entry if a new consumer mounts before gcTime', async () => {
-      const mutation = vi.fn(async () => 42)
-      const useMyMutation = defineMutation({
-        key: ['test'],
-        mutation,
-        gcTime: 1000,
-      })
-
-      const pinia = createPinia()
-      const Comp = defineComponent({
-        setup() {
-          return { ...useMyMutation() }
-        },
-        render: () => null,
-      })
-
-      const w1 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
-
-      w1.vm.mutate()
-      await flushPromises()
-
-      const cache = useMutationCache()
-      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
-
-      w1.unmount()
-      vi.advanceTimersByTime(500)
-      // entry still there
-      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
-
-      // mount new consumer before gcTime
-      const w2 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
-
-      // trigger new mutation
-      w2.vm.mutate()
-      await flushPromises()
-
-      // advance past original gcTime
-      vi.advanceTimersByTime(1000)
-      // entry should still be there since a consumer is mounted
-      expect(cache.getEntries({ key: ['test'] }).length).toBeGreaterThan(0)
+      // remount → scope resumed → watch should fire again
+      mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
+      watchSpy.mockClear()
+      counter.value++
+      await nextTick()
+      expect(watchSpy).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/src/define-mutation.spec.ts
+++ b/src/define-mutation.spec.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { createPinia } from 'pinia'
+import type { App } from 'vue'
+import { createApp, defineComponent, effectScope, inject, provide, ref } from 'vue'
+import { defineMutation } from './define-mutation'
+import { useMutation } from './use-mutation'
+import { PiniaColada } from './pinia-colada'
+import { mockWarn } from '@posva/test-utils'
+
+describe('defineMutation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+  afterEach(async () => {
+    await vi.runAllTimersAsync()
+    vi.restoreAllMocks()
+  })
+
+  enableAutoUnmount(afterEach)
+  mockWarn()
+
+  it('reuses the mutation in multiple places', async () => {
+    const useCreateTodo = defineMutation({
+      mutation: async (text: string) => ({ id: 1, text }),
+    })
+
+    let returnedValues!: ReturnType<typeof useCreateTodo>
+    mount(
+      {
+        setup() {
+          returnedValues = useCreateTodo()
+          return { ...returnedValues }
+        },
+        render: () => null,
+      },
+      {
+        global: {
+          plugins: [createPinia(), PiniaColada],
+        },
+      },
+    )
+
+    const ret = useCreateTodo()
+    expect(ret.mutate).toBe(useCreateTodo().mutate)
+    expect(ret.data).toBe(returnedValues.data)
+  })
+
+  it('reuses the mutation in multiple places with a setup function', async () => {
+    const useCreateTodo = defineMutation(() => {
+      const todoText = ref('')
+      const { data, mutate, ...rest } = useMutation({
+        mutation: async () => ({ id: 1, text: todoText.value }),
+      })
+      return { ...rest, createTodo: mutate, todo: data, todoText }
+    })
+
+    let returnedValues!: ReturnType<typeof useCreateTodo>
+    mount(
+      {
+        setup() {
+          returnedValues = useCreateTodo()
+          return { ...returnedValues }
+        },
+        render: () => null,
+      },
+      {
+        global: {
+          plugins: [createPinia(), PiniaColada],
+        },
+      },
+    )
+
+    const { todo, todoText, createTodo } = useCreateTodo()
+    expect(todo).toBe(useCreateTodo().todo)
+    expect(todo).toBe(returnedValues.todo)
+    expect(todoText).toBe(useCreateTodo().todoText)
+    expect(todoText).toBe(returnedValues.todoText)
+    expect(createTodo).toBe(returnedValues.createTodo)
+  })
+
+  it('injects from app not from parent component', () => {
+    const useData = defineMutation(() => {
+      const value = inject('injected', 'ko')
+      expect(value).toBe('ok')
+      return { value, ...useMutation({ mutation: async () => 42 }) }
+    })
+    const Injector = defineComponent({
+      template: '<p>child</p>',
+      setup() {
+        return { ...useData() }
+      },
+    })
+    mount(
+      {
+        template: '<Injector />',
+        components: { Injector },
+        setup() {
+          provide('injected', 'ko-component')
+          return {}
+        },
+      },
+      {
+        global: {
+          plugins: [createPinia(), PiniaColada],
+          provide: {
+            injected: 'ok',
+          },
+        },
+      },
+    )
+
+    expect(useData().value).toBe('ok')
+  })
+
+  describe('outside of components', () => {
+    let app: App
+    beforeEach(() => {
+      const pinia = createPinia()
+      app = createApp({ render: () => null })
+        .use(pinia)
+        .use(PiniaColada, {})
+      app.mount(document.createElement('div'))
+    })
+    afterEach(() => {
+      app?.unmount()
+    })
+
+    it('reuses the mutation', async () => {
+      const useCreateTodo = defineMutation({
+        mutation: async (text: string) => ({ id: 1, text }),
+      })
+
+      app.runWithContext(() => {
+        const { mutate } = useCreateTodo()
+        expect(mutate).toBe(useCreateTodo().mutate)
+      })
+    })
+
+    it('reuses the mutation with a setup function', async () => {
+      const useCreateTodo = defineMutation(() => {
+        const todoText = ref('')
+        const { data, mutate, ...rest } = useMutation({
+          mutation: async () => ({ id: 1, text: todoText.value }),
+        })
+        return { ...rest, createTodo: mutate, todo: data, todoText }
+      })
+
+      app.runWithContext(() => {
+        const { todo, todoText } = useCreateTodo()
+        expect(todo).toBe(useCreateTodo().todo)
+        expect(todoText).toBe(useCreateTodo().todoText)
+      })
+    })
+  })
+})

--- a/src/define-mutation.spec.ts
+++ b/src/define-mutation.spec.ts
@@ -2,9 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
 import type { App } from 'vue'
-import { createApp, defineComponent, effectScope, inject, provide, ref } from 'vue'
+import { computed, createApp, defineComponent, effectScope, inject, provide, ref } from 'vue'
 import { defineMutation } from './define-mutation'
 import { useMutation } from './use-mutation'
+import { useMutationCache } from './mutation-store'
 import { PiniaColada } from './pinia-colada'
 import { mockWarn } from '@posva/test-utils'
 
@@ -111,6 +112,204 @@ describe('defineMutation', () => {
     )
 
     expect(useData().value).toBe('ok')
+  })
+
+  it('still works after one consumer unmounts', async () => {
+    const mutation = vi.fn(async (text: string) => ({ id: 1, text }))
+    const useCreateTodo = defineMutation({
+      key: ['todos', 'create'],
+      mutation,
+    })
+
+    const pinia = createPinia()
+
+    const Comp1 = defineComponent({
+      setup() {
+        return { ...useCreateTodo() }
+      },
+      render: () => null,
+    })
+    const Comp2 = defineComponent({
+      setup() {
+        return { ...useCreateTodo() }
+      },
+      render: () => null,
+    })
+
+    const w1 = mount(Comp1, {
+      global: { plugins: [pinia, PiniaColada] },
+    })
+    const w2 = mount(Comp2, {
+      global: { plugins: [pinia, PiniaColada] },
+    })
+
+    // mutate via component 1
+    w1.vm.mutate('hello')
+    await flushPromises()
+    expect(mutation).toHaveBeenCalledTimes(1)
+    expect(w2.vm.data).toEqual({ id: 1, text: 'hello' })
+
+    // unmount component 1
+    w1.unmount()
+
+    // component 2 should still be able to mutate
+    w2.vm.mutate('world')
+    await flushPromises()
+    expect(mutation).toHaveBeenCalledTimes(2)
+    expect(w2.vm.data).toEqual({ id: 1, text: 'world' })
+  })
+
+  describe('scope lifecycle', () => {
+    it('pauses computed effects when all consumers unmount', async () => {
+      const mutation = vi.fn(async () => 42)
+      const useMyMutation = defineMutation(() => {
+        const { data, ...rest } = useMutation({ mutation })
+        const doubled = computed(() => (data.value ? data.value * 2 : null))
+        return { ...rest, data, doubled }
+      })
+
+      const pinia = createPinia()
+      const wrapper = mount(
+        defineComponent({
+          setup() {
+            return { ...useMyMutation() }
+          },
+          render: () => null,
+        }),
+        { global: { plugins: [pinia, PiniaColada] } },
+      )
+
+      wrapper.vm.mutate()
+      await flushPromises()
+      expect(wrapper.vm.doubled).toBe(84)
+
+      wrapper.unmount()
+
+      // after unmount, calling the composable in a new component should resume the scope
+      const w2 = mount(
+        defineComponent({
+          setup() {
+            return { ...useMyMutation() }
+          },
+          render: () => null,
+        }),
+        { global: { plugins: [pinia, PiniaColada] } },
+      )
+
+      // data is preserved from the previous mutation
+      expect(w2.vm.doubled).toBe(84)
+
+      w2.vm.mutate()
+      await flushPromises()
+      expect(w2.vm.doubled).toBe(84)
+    })
+
+    it('resumes the scope when a new consumer mounts after all unmounted', async () => {
+      const mutation = vi.fn(async () => 42)
+      const useMyMutation = defineMutation({
+        mutation,
+      })
+
+      const pinia = createPinia()
+      const Comp = defineComponent({
+        setup() {
+          return { ...useMyMutation() }
+        },
+        render: () => null,
+      })
+
+      const w1 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
+      w1.vm.mutate()
+      await flushPromises()
+      expect(w1.vm.data).toBe(42)
+
+      w1.unmount()
+
+      // mount a new consumer - scope should resume
+      const w2 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
+      // data from previous mutation is still accessible
+      expect(w2.vm.data).toBe(42)
+
+      // can still mutate
+      mutation.mockResolvedValueOnce(99)
+      w2.vm.mutate()
+      await flushPromises()
+      expect(w2.vm.data).toBe(99)
+    })
+  })
+
+  describe('gcTime', () => {
+    it('keeps the entry in cache while a consumer is mounted', async () => {
+      const mutation = vi.fn(async () => 42)
+      const useMyMutation = defineMutation({
+        key: ['test'],
+        mutation,
+        gcTime: 1000,
+      })
+
+      const pinia = createPinia()
+      const wrapper = mount(
+        defineComponent({
+          setup() {
+            return { ...useMyMutation() }
+          },
+          render: () => null,
+        }),
+        { global: { plugins: [pinia, PiniaColada] } },
+      )
+
+      wrapper.vm.mutate()
+      await flushPromises()
+
+      const cache = useMutationCache()
+      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
+
+      // gcTime passes but component is still mounted → entry stays
+      vi.advanceTimersByTime(2000)
+      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
+    })
+
+    it('keeps the entry if a new consumer mounts before gcTime', async () => {
+      const mutation = vi.fn(async () => 42)
+      const useMyMutation = defineMutation({
+        key: ['test'],
+        mutation,
+        gcTime: 1000,
+      })
+
+      const pinia = createPinia()
+      const Comp = defineComponent({
+        setup() {
+          return { ...useMyMutation() }
+        },
+        render: () => null,
+      })
+
+      const w1 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
+
+      w1.vm.mutate()
+      await flushPromises()
+
+      const cache = useMutationCache()
+      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
+
+      w1.unmount()
+      vi.advanceTimersByTime(500)
+      // entry still there
+      expect(cache.getEntries({ key: ['test'] })).toHaveLength(1)
+
+      // mount new consumer before gcTime
+      const w2 = mount(Comp, { global: { plugins: [pinia, PiniaColada] } })
+
+      // trigger new mutation
+      w2.vm.mutate()
+      await flushPromises()
+
+      // advance past original gcTime
+      vi.advanceTimersByTime(1000)
+      // entry should still be there since a consumer is mounted
+      expect(cache.getEntries({ key: ['test'] }).length).toBeGreaterThan(0)
+    })
   })
 
   describe('outside of components', () => {

--- a/src/define-mutation.spec.ts
+++ b/src/define-mutation.spec.ts
@@ -41,9 +41,11 @@ describe('defineMutation', () => {
       },
     )
 
+    // calling outside a component/scope still works but warns
     const ret = useCreateTodo()
     expect(ret.mutate).toBe(useCreateTodo().mutate)
     expect(ret.data).toBe(returnedValues.data)
+    expect('outside of a component or effect scope').toHaveBeenWarned()
   })
 
   it('reuses the mutation in multiple places with a setup function', async () => {
@@ -71,12 +73,14 @@ describe('defineMutation', () => {
       },
     )
 
+    // calling outside a component/scope still works but warns
     const { todo, todoText, createTodo } = useCreateTodo()
     expect(todo).toBe(useCreateTodo().todo)
     expect(todo).toBe(returnedValues.todo)
     expect(todoText).toBe(useCreateTodo().todoText)
     expect(todoText).toBe(returnedValues.todoText)
     expect(createTodo).toBe(returnedValues.createTodo)
+    expect('outside of a component or effect scope').toHaveBeenWarned()
   })
 
   it('injects from app not from parent component', () => {
@@ -110,7 +114,9 @@ describe('defineMutation', () => {
       },
     )
 
+    // calling outside a component/scope still works but warns
     expect(useData().value).toBe('ok')
+    expect('outside of a component or effect scope').toHaveBeenWarned()
   })
 
   it('still works after one consumer unmounts', async () => {
@@ -158,6 +164,27 @@ describe('defineMutation', () => {
     expect(w2.vm.data).toEqual({ id: 1, text: 'world' })
   })
 
+  it('warns when called outside of a component or effect scope', () => {
+    const useMyMutation = defineMutation({
+      mutation: async () => 42,
+    })
+
+    const pinia = createPinia()
+    mount(
+      defineComponent({
+        setup() {
+          return { ...useMyMutation() }
+        },
+        render: () => null,
+      }),
+      { global: { plugins: [pinia, PiniaColada] } },
+    )
+
+    // calling outside any scope warns about potential leak
+    useMyMutation()
+    expect('outside of a component or effect scope').toHaveBeenWarned()
+  })
+
   describe('scope lifecycle', () => {
     it('pauses effects when all consumers unmount and resumes on remount', async () => {
       const watchSpy = vi.fn()
@@ -195,6 +222,9 @@ describe('defineMutation', () => {
       counter.value++
       await nextTick()
       expect(watchSpy).toHaveBeenCalledTimes(1)
+
+      // the call to useMyMutation() outside a component warns
+      expect('outside of a component or effect scope').toHaveBeenWarned()
     })
   })
 
@@ -220,6 +250,7 @@ describe('defineMutation', () => {
         const { mutate } = useCreateTodo()
         expect(mutate).toBe(useCreateTodo().mutate)
       })
+      expect('outside of a component or effect scope').toHaveBeenWarned()
     })
 
     it('reuses the mutation with a setup function', async () => {
@@ -236,6 +267,7 @@ describe('defineMutation', () => {
         expect(todo).toBe(useCreateTodo().todo)
         expect(todoText).toBe(useCreateTodo().todoText)
       })
+      expect('outside of a component or effect scope').toHaveBeenWarned()
     })
   })
 })

--- a/src/define-mutation.ts
+++ b/src/define-mutation.ts
@@ -73,6 +73,10 @@ export function defineMutation(
           scope.pause()
         }
       })
+    } else if (process.env.NODE_ENV !== 'production') {
+      console.warn(
+        `[@pinia/colada]: defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks. Make sure to call it inside a component setup, an effect scope, or a store.`,
+      )
     }
 
     return ret

--- a/src/define-mutation.ts
+++ b/src/define-mutation.ts
@@ -1,3 +1,4 @@
+import { getCurrentInstance, getCurrentScope, onScopeDispose } from 'vue'
 import { useMutationCache } from './mutation-store'
 import type { ErrorDefault } from './types-extension'
 import { useMutation } from './use-mutation'
@@ -57,8 +58,24 @@ export function defineMutation(
 ): () => unknown {
   const setupFn =
     typeof optionsOrSetup === 'function' ? optionsOrSetup : () => useMutation(optionsOrSetup)
+
+  let refCount = 0
   return () => {
     const mutationCache = useMutationCache()
-    return mutationCache.ensureDefinedMutation(setupFn)
+    const currentScope = getCurrentInstance() || getCurrentScope()
+
+    const [ret, scope, isPaused] = mutationCache.ensureDefinedMutation(setupFn)
+
+    if (currentScope) {
+      refCount++
+      onScopeDispose(() => {
+        if (--refCount < 1) {
+          scope.pause()
+          isPaused.value = true
+        }
+      })
+    }
+
+    return ret
   }
 }

--- a/src/define-mutation.ts
+++ b/src/define-mutation.ts
@@ -64,14 +64,13 @@ export function defineMutation(
     const mutationCache = useMutationCache()
     const currentScope = getCurrentInstance() || getCurrentScope()
 
-    const [ret, scope, isPaused] = mutationCache.ensureDefinedMutation(setupFn)
+    const [ret, scope] = mutationCache.ensureDefinedMutation(setupFn)
 
     if (currentScope) {
       refCount++
       onScopeDispose(() => {
         if (--refCount < 1) {
           scope.pause()
-          isPaused.value = true
         }
       })
     }

--- a/src/mutation-store.ts
+++ b/src/mutation-store.ts
@@ -1,7 +1,14 @@
-import type { ShallowRef } from 'vue'
 import type { AsyncStatus, DataState } from './data-state'
-import { defineStore, skipHydrate } from 'pinia'
-import { customRef, getCurrentScope, hasInjectionContext, markRaw, shallowRef } from 'vue'
+import { defineStore, getActivePinia, skipHydrate } from 'pinia'
+import {
+  customRef,
+  effectScope,
+  getCurrentScope,
+  hasInjectionContext,
+  markRaw,
+  shallowRef,
+} from 'vue'
+import type { App, EffectScope, ShallowRef } from 'vue'
 import { find } from './entry-keys'
 import type { EntryFilter } from './entry-filter'
 import type { _EmptyObject } from './utils'
@@ -104,6 +111,12 @@ export type UseMutationEntryFilter = EntryFilter<UseMutationEntry>
 export const MUTATION_STORE_ID = '_pc_mutation'
 
 /**
+ * A mutation entry that is defined with {@link defineMutation}.
+ * @internal
+ */
+type DefineMutationEntry = [returnValue: unknown, effect: EffectScope, paused: ShallowRef<boolean>]
+
+/**
  * Composable to get the cache of the mutations. As any other composable, it
  * can be used inside the `setup` function of a component, within another
  * composable, or in injectable contexts like stores and navigation guards.
@@ -145,8 +158,12 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
     }
   }
 
+  const app: App<unknown> =
+    // @ts-expect-error: internal
+    getActivePinia()!._a
+
   const globalOptions = useMutationOptions()
-  const defineMutationMap = new WeakMap<() => unknown, unknown>()
+  const defineMutationMap = new WeakMap<() => unknown, DefineMutationEntry>()
 
   let nextMutationId = 1
 
@@ -245,16 +262,23 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
   }
 
   /**
-   * Ensures a query created with {@link defineMutation} is present in the cache. If it's not, it creates a new one.
-   * @param fn - function that defines the query
+   * Ensures a mutation created with {@link defineMutation} is present in the cache. If it's not, it creates a new one.
+   * @param fn - function that defines the mutation
    */
   const ensureDefinedMutation = action(<T>(fn: () => T) => {
-    let defineMutationResult = defineMutationMap.get(fn)
-    if (!defineMutationResult) {
-      defineMutationMap.set(fn, (defineMutationResult = scope.run(fn)))
+    let entry = defineMutationMap.get(fn)
+    if (!entry) {
+      entry = scope.run(() => [null, effectScope(), shallowRef(false)])! as DefineMutationEntry
+
+      entry[0] = app.runWithContext(() => entry![1].run(fn)!)
+      defineMutationMap.set(fn, entry)
+    } else {
+      // ensure the scope is active so effects run
+      entry[1].resume()
+      entry[2].value = false
     }
 
-    return defineMutationResult
+    return entry
   })
 
   /**

--- a/src/mutation-store.ts
+++ b/src/mutation-store.ts
@@ -114,7 +114,7 @@ export const MUTATION_STORE_ID = '_pc_mutation'
  * A mutation entry that is defined with {@link defineMutation}.
  * @internal
  */
-type DefineMutationEntry = [returnValue: unknown, effect: EffectScope, paused: ShallowRef<boolean>]
+type DefineMutationEntry = [returnValue: unknown, effect: EffectScope]
 
 /**
  * Composable to get the cache of the mutations. As any other composable, it
@@ -268,14 +268,13 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
   const ensureDefinedMutation = action(<T>(fn: () => T) => {
     let entry = defineMutationMap.get(fn)
     if (!entry) {
-      entry = scope.run(() => [null, effectScope(), shallowRef(false)])! as DefineMutationEntry
+      entry = scope.run(() => [null, effectScope()])! as DefineMutationEntry
 
       entry[0] = app.runWithContext(() => entry![1].run(fn)!)
       defineMutationMap.set(fn, entry)
     } else {
       // ensure the scope is active so effects run
       entry[1].resume()
-      entry[2].value = false
     }
 
     return entry


### PR DESCRIPTION
## Summary

- `ensureDefinedMutation` now creates a dedicated `effectScope()` per defined mutation (was running in the store's root scope)
- Uses `app.runWithContext()` so `inject()` resolves from the app, not the component tree
- `defineMutation` now tracks consumers with ref counting and pauses the scope when all unmount — matching `defineQuery` behavior

## Test plan

- [x] New `define-mutation.spec.ts` with 5 tests: reuse (options + setup syntax), app injection, outside-component usage
- [x] Full suite green (485 tests pass)
- [x] No type errors

Closes #85

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests verifying shared mutation instances across consumers, lifecycle behavior across mounts/unmounts, pause/resume of internal watchers, app-level dependency resolution, and usage outside component setup.

* **Bug Fixes**
  * Improved mutation caching and lifecycle management with reference counting and scope-aware pause/resume so instances and state are reliably reused; emits a warning when used outside component/effect scopes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->