### PR TITLE
fix(cache-persister): await captured promise on async restore

### DIFF
--- a/plugins/cache-persister/src/cache-persister.spec.ts
+++ b/plugins/cache-persister/src/cache-persister.spec.ts
@@ -430,6 +430,19 @@ describe('PiniaColadaCachePersister', () => {
       expect(queryCache.getQueryData(['async-restored'])).toBe('async-cached')
     })
 
+    it('calls getItem once when restoring from async storage', async () => {
+      const storage = createAsyncStorage()
+      storage.data['pinia-colada-cache'] = JSON.stringify({
+        '["once"]': ['cached', null, 0, {}],
+      })
+
+      factory({ key: ['once'], query: async () => 'fresh' }, { storage })
+
+      await flushPromises()
+
+      expect(storage.getItem).toHaveBeenCalledTimes(1)
+    })
+
     it('isCacheReady waits for async restore', async () => {
       const storage = createAsyncStorage()
       storage.data['pinia-colada-cache'] = JSON.stringify({

--- a/plugins/cache-persister/src/cache-persister.ts
+++ b/plugins/cache-persister/src/cache-persister.ts
@@ -178,7 +178,7 @@ export function PiniaColadaCachePersister(
       try {
         const storedPromise = storage.getItem(key)
         // avoid one extra await if storage is sync
-        const stored = storedPromise instanceof Promise ? await storage.getItem(key) : storedPromise
+        const stored = storedPromise instanceof Promise ? await storedPromise : storedPromise
         if (stored) {
           const parsed = JSON.parse(stored) as Record<string, _UseQueryEntryNodeValueSerialized>
           hydrateQueryCache(queryCache, parsed)


### PR DESCRIPTION
The async restore path at `plugins/cache-persister/src/cache-persister.ts:181` awaits a fresh `storage.getItem(key)` call instead of the already-captured `storedPromise`, causing two reads on every app boot when storage is async (IndexedDB, AsyncStorage, remote KV, etc.). Sync storage (localStorage) is unaffected.

Introduced in 0f536f5 ("fix: avoid extra tick") — the variable name `storedPromise` and the in-code comment both show the original intent was to reuse the captured promise; the async branch just missed it.

### Change

```diff
- const stored = storedPromise instanceof Promise ? await storage.getItem(key) : storedPromise
+ const stored = storedPromise instanceof Promise ? await storedPromise : storedPromise
```

### Test

Adds a call-count assertion to the existing async-storage test block. Without the fix, `getItem` is called twice on restore; with the fix, once.

---

Created with assistance by Claude Code. Vetted/validated by Danny-Devs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test case for async-storage cache restoration to validate that cached data is properly retrieved from persistent storage and restored correctly on initialization

* **Refactor**
  * Improved cache restoration efficiency by streamlining the underlying storage read logic to prevent redundant operations and unnecessary storage requests during cache rehydration processes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->