### PR TITLE
fix(retry): prevent retryMap key collisions for structurally distinct keys

### DIFF
--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -530,6 +530,89 @@ describe('Pinia Colada Retry Plugin', () => {
     })
   })
 
+  describe('retryMap key uniqueness', () => {
+    function twoQueryFactory(a: UseQueryOptions, b: UseQueryOptions) {
+      const wrapper = mount(
+        defineComponent({
+          template: '<div></div>',
+          setup() {
+            const qa = useQuery(a)
+            const qb = useQuery(b)
+            return { qa, qb }
+          },
+        }),
+        {
+          global: {
+            plugins: [
+              createPinia(),
+              [PiniaColada, { plugins: [PiniaColadaRetry(RETRY_OPTIONS_DEFAULTS)] }],
+            ],
+          },
+        },
+      )
+      return { wrapper }
+    }
+
+    it('tracks retry state separately for keys with a shared join("/") representation', async () => {
+      const queryA = vi.fn(async () => {
+        throw new Error('A')
+      })
+      const queryB = vi.fn(async () => {
+        throw new Error('B')
+      })
+
+      twoQueryFactory(
+        { key: ['a/b'], query: queryA, retry: 2 },
+        { key: ['a', 'b'], query: queryB, retry: 2 },
+      )
+
+      // both initial fetches fail
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(1)
+      expect(queryB).toHaveBeenCalledTimes(1)
+
+      // first retry fires for each query (retryCount: 0 → 1)
+      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(2)
+      expect(queryB).toHaveBeenCalledTimes(2)
+
+      // second retry fires for each query (retryCount: 1 → 2)
+      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(3)
+      expect(queryB).toHaveBeenCalledTimes(3)
+    })
+
+    it('tracks retry state separately for object-valued keys', async () => {
+      const queryA = vi.fn(async () => {
+        throw new Error('A')
+      })
+      const queryB = vi.fn(async () => {
+        throw new Error('B')
+      })
+
+      twoQueryFactory(
+        { key: ['users', { id: 1 }], query: queryA, retry: 2 },
+        { key: ['users', { id: 2 }], query: queryB, retry: 2 },
+      )
+
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(1)
+      expect(queryB).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(2)
+      expect(queryB).toHaveBeenCalledTimes(2)
+
+      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
+      await flushPromises()
+      expect(queryA).toHaveBeenCalledTimes(3)
+      expect(queryB).toHaveBeenCalledTimes(3)
+    })
+  })
+
   it('no retries if enabled becomes false while waiting', async () => {
     const query = vi.fn(async () => {
       throw new Error('ko')

--- a/plugins/retry/src/retry.ts
+++ b/plugins/retry/src/retry.ts
@@ -90,7 +90,7 @@ export function PiniaColadaRetry(
       // cleanup all pending retries when data is deleted (means the data is not needed anymore)
       if (name === 'remove') {
         const [cacheEntry] = args
-        const key = cacheEntry.key.join('/')
+        const key = cacheEntry.keyHash
         const entry = retryMap.get(key)
         if (entry) {
           clearTimeout(entry.timeoutId)
@@ -115,7 +115,7 @@ export function PiniaColadaRetry(
       // avoid setting up anything at all
       if (retry === 0) return
 
-      const key = queryEntry.key.join('/')
+      const key = queryEntry.keyHash
 
       // clear any pending retry
       clearTimeout(retryMap.get(key)?.timeoutId)


### PR DESCRIPTION
## Summary

`plugins/retry` uses `entry.key.join('/')` as its `retryMap` key, which collides for structurally distinct keys — silently cancelling sibling retries when colliding queries fail around the same time.

## The bug

`Array.prototype.join('/')` is lossy:
- `['a/b'].join('/')` === `['a', 'b'].join('/')` === `"a/b"`
- `['users', {id: 1}]` and `['users', {id: 2}]` both coerce to `"users/[object Object]"`

The cache disambiguates these via `keyHash`; the retry plugin does not. When a colliding query's retry fires, the internal `queryCache.fetch()` re-enters the `'fetch'` handler and runs `clearTimeout` on the shared `retryMap` entry — cancelling the sibling's scheduled retry.

## Fix

Swap `entry.key.join('/')` → `entry.keyHash` at the `'remove'` and `'fetch'` handlers. `keyHash` is already public on `UseQueryEntry` and uses the same canonical serialization the cache keys entries with.

## Regression tests

Two tests under `retryMap key uniqueness`, each mounting colliding-key pairs and asserting independent retry cycles:

- `['a/b']` vs `['a', 'b']`
- `['users', {id: 1}]` vs `['users', {id: 2}]`

Both fail on the buggy code and pass on the fix.

## Test plan

- [x] `pnpm -F @pinia/colada-plugin-retry exec vitest run` — 23/23 pass
- [x] Full library suite — 498 pass, 11 todo, 0 fail
- [x] `oxlint` clean
- [x] Two-sided verification (revert → 2 tests fail, restore → all pass)

---

Created with assistance by Claude Code. Vetted/validated by Danny-Devs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for independent retry scheduling across multiple simultaneous queries, verifying that different query keys correctly maintain separate retry scheduling state.

* **Refactor**
  * Updated retry bookkeeping mechanism to use consistent key identification across all retry operations, ensuring reliable handling of retry scheduling and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->