### PR TITLE
fix(retry): clear scheduled retry on cancel

### DIFF
--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -2,7 +2,7 @@ import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createPinia } from 'pinia'
-import { useQuery, PiniaColada } from '@pinia/colada'
+import { useQuery, PiniaColada, useQueryCache } from '@pinia/colada'
 import type { UseQueryOptions } from '@pinia/colada'
 import { PiniaColadaRetry } from './retry'
 
@@ -23,6 +23,7 @@ describe('Pinia Colada Retry Plugin', () => {
   } as const
 
   function factory(queryOptions: UseQueryOptions) {
+    const pinia = createPinia()
     const wrapper = mount(
       defineComponent({
         template: '<div></div>',
@@ -33,7 +34,7 @@ describe('Pinia Colada Retry Plugin', () => {
       {
         global: {
           plugins: [
-            createPinia(),
+            pinia,
             [
               // split lines
               PiniaColada,
@@ -44,7 +45,7 @@ describe('Pinia Colada Retry Plugin', () => {
       },
     )
 
-    return { wrapper }
+    return { wrapper, pinia }
   }
 
   it('apply global retry options', async () => {
@@ -635,5 +636,59 @@ describe('Pinia Colada Retry Plugin', () => {
     vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
     await flushPromises()
     expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  describe('cancel behavior', () => {
+    it('does not fire the scheduled retry after queryCache.cancel()', async () => {
+      const query = vi.fn(async () => {
+        throw new Error('ko')
+      })
+
+      const { pinia } = factory({
+        key: ['key'],
+        query,
+        retry: 3,
+      })
+
+      // initial fetch fails, retry scheduled
+      await flushPromises()
+      expect(query).toHaveBeenCalledTimes(1)
+
+      const queryCache = useQueryCache(pinia)
+      const entry = queryCache.getEntries({ key: ['key'] })[0]!
+      queryCache.cancel(entry)
+
+      // retry window elapses - no new fetch should fire
+      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay * 5)
+      await flushPromises()
+      expect(query).toHaveBeenCalledTimes(1)
+    })
+
+    it('resets retry UI flags on cancel', async () => {
+      const query = vi.fn(async () => {
+        throw new Error('ko')
+      })
+
+      const { wrapper, pinia } = factory({
+        key: ['key'],
+        query,
+        retry: 3,
+      })
+
+      // initial fetch fails, retry scheduled - flags set
+      await flushPromises()
+      expect((wrapper.vm as any).isRetrying).toBe(true)
+      expect((wrapper.vm as any).retryCount).toBe(1)
+      expect((wrapper.vm as any).retryError).toEqual(new Error('ko'))
+
+      const queryCache = useQueryCache(pinia)
+      const entry = queryCache.getEntries({ key: ['key'] })[0]!
+      queryCache.cancel(entry)
+      await flushPromises()
+
+      expect((wrapper.vm as any).isRetrying).toBe(false)
+      expect((wrapper.vm as any).retryCount).toBe(0)
+      expect((wrapper.vm as any).retryError).toBeNull()
+    })
   })
 })

--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -644,7 +644,7 @@ describe('Pinia Colada Retry Plugin', () => {
         throw new Error('ko')
       })
 
-      const { pinia } = factory({
+      const { pinia, wrapper } = factory({
         key: ['key'],
         query,
         retry: 3,
@@ -653,10 +653,11 @@ describe('Pinia Colada Retry Plugin', () => {
       // initial fetch fails, retry scheduled
       await flushPromises()
       expect(query).toHaveBeenCalledTimes(1)
+      expect(wrapper.vm.isRetrying).toBe(true)
 
       const queryCache = useQueryCache(pinia)
-      const entry = queryCache.getEntries({ key: ['key'] })[0]!
-      queryCache.cancel(entry)
+      queryCache.cancelQueries({ key: ['key'] })
+      expect(wrapper.vm.isRetrying).toBe(false)
 
       // retry window elapses - no new fetch should fire
       vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay * 5)
@@ -677,18 +678,18 @@ describe('Pinia Colada Retry Plugin', () => {
 
       // initial fetch fails, retry scheduled - flags set
       await flushPromises()
-      expect((wrapper.vm as any).isRetrying).toBe(true)
-      expect((wrapper.vm as any).retryCount).toBe(1)
-      expect((wrapper.vm as any).retryError).toEqual(new Error('ko'))
+      expect(wrapper.vm.isRetrying).toBe(true)
+      expect(wrapper.vm.retryCount).toBe(1)
+      expect(wrapper.vm.retryError).toEqual(new Error('ko'))
 
       const queryCache = useQueryCache(pinia)
       const entry = queryCache.getEntries({ key: ['key'] })[0]!
       queryCache.cancel(entry)
       await flushPromises()
 
-      expect((wrapper.vm as any).isRetrying).toBe(false)
-      expect((wrapper.vm as any).retryCount).toBe(0)
-      expect((wrapper.vm as any).retryError).toBeNull()
+      expect(wrapper.vm.isRetrying).toBe(false)
+      expect(wrapper.vm.retryCount).toBe(0)
+      expect(wrapper.vm.retryError).toBeNull()
     })
   })
 })

--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -638,58 +638,55 @@ describe('Pinia Colada Retry Plugin', () => {
     expect(query).toHaveBeenCalledTimes(1)
   })
 
-  describe('cancel behavior', () => {
-    it('does not fire the scheduled retry after queryCache.cancel()', async () => {
-      const query = vi.fn(async () => {
-        throw new Error('ko')
-      })
-
-      const { pinia, wrapper } = factory({
-        key: ['key'],
-        query,
-        retry: 3,
-      })
-
-      // initial fetch fails, retry scheduled
-      await flushPromises()
-      expect(query).toHaveBeenCalledTimes(1)
-      expect(wrapper.vm.isRetrying).toBe(true)
-
-      const queryCache = useQueryCache(pinia)
-      queryCache.cancelQueries({ key: ['key'] })
-      expect(wrapper.vm.isRetrying).toBe(false)
-
-      // retry window elapses - no new fetch should fire
-      vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay * 5)
-      await flushPromises()
-      expect(query).toHaveBeenCalledTimes(1)
+  it('cancel ongoing retries if query is cancelled', async () => {
+    const query = vi.fn(async () => {
+      throw new Error('ko')
     })
 
-    it('resets retry UI flags on cancel', async () => {
-      const query = vi.fn(async () => {
-        throw new Error('ko')
-      })
-
-      const { wrapper, pinia } = factory({
-        key: ['key'],
-        query,
-        retry: 3,
-      })
-
-      // initial fetch fails, retry scheduled - flags set
-      await flushPromises()
-      expect(wrapper.vm.isRetrying).toBe(true)
-      expect(wrapper.vm.retryCount).toBe(1)
-      expect(wrapper.vm.retryError).toEqual(new Error('ko'))
-
-      const queryCache = useQueryCache(pinia)
-      const entry = queryCache.getEntries({ key: ['key'] })[0]!
-      queryCache.cancel(entry)
-      await flushPromises()
-
-      expect(wrapper.vm.isRetrying).toBe(false)
-      expect(wrapper.vm.retryCount).toBe(0)
-      expect(wrapper.vm.retryError).toBeNull()
+    const { pinia, wrapper } = factory({
+      key: ['key'],
+      query,
+      retry: 3,
     })
+    const queryCache = useQueryCache(pinia)
+
+    // initial fetch fails, retry scheduled
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(wrapper.vm.isRetrying).toBe(true)
+
+    queryCache.cancelQueries({ key: ['key'] })
+    expect(wrapper.vm.isRetrying).toBe(false)
+
+    // retry window elapses - no new fetch should fire
+    vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay * 5)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  })
+
+  it('resets retry state when query is cancelled', async () => {
+    const query = vi.fn(async () => {
+      throw new Error('ko')
+    })
+
+    const { wrapper, pinia } = factory({
+      key: ['key'],
+      query,
+      retry: 3,
+    })
+    const queryCache = useQueryCache(pinia)
+
+    // initial fetch fails, retry scheduled - flags set
+    await flushPromises()
+    expect(wrapper.vm.isRetrying).toBe(true)
+    expect(wrapper.vm.retryCount).toBe(1)
+    expect(wrapper.vm.retryError).toEqual(new Error('ko'))
+
+    queryCache.cancelQueries({ key: ['key'] })
+    await flushPromises()
+
+    expect(wrapper.vm.isRetrying).toBe(false)
+    expect(wrapper.vm.retryCount).toBe(0)
+    expect(wrapper.vm.retryError).toBeNull()
   })
 })

--- a/plugins/retry/src/retry.ts
+++ b/plugins/retry/src/retry.ts
@@ -82,13 +82,15 @@ export function PiniaColadaRetry(
           entry.ext.retryError = shallowRef(null)
         })
         if (process.env.NODE_ENV === 'development') {
-          entry.ext.retry = { isRetrying: false, retryCount: 0, retryError: null as unknown }
+          entry.ext.retry = {
+            isRetrying: false,
+            retryCount: 0,
+            retryError: null,
+          }
         }
         return
-      }
-
-      // cleanup all pending retries when data is deleted (means the data is not needed anymore)
-      if (name === 'remove') {
+      } else if (name === 'remove' || name === 'cancel') {
+        // cleanup all pending retries
         const [cacheEntry] = args
         const key = cacheEntry.keyHash
         const entry = retryMap.get(key)
@@ -96,137 +98,127 @@ export function PiniaColadaRetry(
           clearTimeout(entry.timeoutId)
           retryMap.delete(key)
         }
-      }
-
-      // cleanup any pending retry when the user cancels the query
-      if (name === 'cancel') {
-        const [cacheEntry] = args
-        const key = cacheEntry.keyHash
-        const entry = retryMap.get(key)
-        if (entry) {
-          clearTimeout(entry.timeoutId)
-          retryMap.delete(key)
-        }
+        // also reset the state
         cacheEntry.ext.isRetrying.value = false
         cacheEntry.ext.retryCount.value = 0
         cacheEntry.ext.retryError.value = null
+
         if (process.env.NODE_ENV === 'development' && cacheEntry.ext.retry) {
           cacheEntry.ext.retry.isRetrying = false
           cacheEntry.ext.retry.retryCount = 0
           cacheEntry.ext.retry.retryError = null
         }
-      }
+      } else if (name === 'fetch') {
+        const [queryEntry] = args
+        const localOptions = queryEntry.options?.retry
 
-      if (name !== 'fetch') return
-      const [queryEntry] = args
-      const localOptions = queryEntry.options?.retry
+        const options = {
+          ...(typeof localOptions === 'object'
+            ? localOptions
+            : {
+                retry: localOptions,
+              }),
+        } satisfies RetryOptions
 
-      const options = {
-        ...(typeof localOptions === 'object'
-          ? localOptions
-          : {
-              retry: localOptions,
-            }),
-      } satisfies RetryOptions
+        const retry = options.retry ?? defaults.retry
+        const delay = options.delay ?? defaults.delay
+        // avoid setting up anything at all
+        if (retry === 0) return
 
-      const retry = options.retry ?? defaults.retry
-      const delay = options.delay ?? defaults.delay
-      // avoid setting up anything at all
-      if (retry === 0) return
+        const key = queryEntry.keyHash
 
-      const key = queryEntry.keyHash
-
-      // clear any pending retry
-      clearTimeout(retryMap.get(key)?.timeoutId)
-      // if the user manually calls the action, reset the retry count
-      if (!isInternalCall) {
-        retryMap.delete(key)
-        queryEntry.ext.isRetrying.value = false
-        queryEntry.ext.retryCount.value = 0
-        queryEntry.ext.retryError.value = null
-        if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
-          queryEntry.ext.retry.isRetrying = false
-          queryEntry.ext.retry.retryCount = 0
-          queryEntry.ext.retry.retryError = null
-        }
-      }
-
-      // capture state before the fetch runs so we can revert during retries
-      const previousState = queryEntry.state.value
-
-      const retryFetch = () => {
-        if (queryEntry.state.value.status === 'error') {
-          const error = queryEntry.state.value.error
-          // ensure the entry exists
-          let entry = retryMap.get(key)
-          if (!entry) {
-            entry = { retryCount: 0 }
-            retryMap.set(key, entry)
-          }
-
-          const shouldRetry =
-            typeof retry === 'number' ? retry > entry.retryCount : retry(entry.retryCount, error)
-
-          if (shouldRetry) {
-            queryEntry.ext.isRetrying.value = true
-            queryEntry.ext.retryCount.value = entry.retryCount + 1
-            queryEntry.ext.retryError.value = error
-            if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
-              queryEntry.ext.retry.isRetrying = true
-              queryEntry.ext.retry.retryCount = entry.retryCount + 1
-              queryEntry.ext.retry.retryError = error
-            }
-            // revert to pre-fetch state so the error is only visible via retryError
-            queryEntry.state.value = previousState
-            const delayTime = typeof delay === 'function' ? delay(entry.retryCount) : delay
-            entry.timeoutId = setTimeout(() => {
-              if (!queryEntry.active || toValue(queryEntry.options?.enabled) === false) {
-                retryMap.delete(key)
-                queryEntry.ext.isRetrying.value = false
-                queryEntry.ext.retryCount.value = 0
-                queryEntry.ext.retryError.value = null
-                if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
-                  queryEntry.ext.retry.isRetrying = false
-                  queryEntry.ext.retry.retryCount = 0
-                  queryEntry.ext.retry.retryError = null
-                }
-                return
-              }
-              // NOTE: we could add some default error handler
-              isInternalCall = true
-              Promise.resolve(queryCache.fetch(queryEntry)).catch(
-                process.env.NODE_ENV !== 'test' ? console.error : () => {},
-              )
-              isInternalCall = false
-              if (entry) {
-                entry.retryCount++
-              }
-            }, delayTime)
-          } else {
-            // remove the entry if we are not going to retry
-            queryEntry.ext.isRetrying.value = false
-            queryEntry.ext.retryError.value = null
-            retryMap.delete(key)
-            if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
-              queryEntry.ext.retry.isRetrying = false
-              queryEntry.ext.retry.retryError = null
-            }
-          }
-        } else {
-          // remove the entry if it worked out to reset it
+        // clear any pending retry
+        clearTimeout(retryMap.get(key)?.timeoutId)
+        // if the user manually calls the action, reset the retry count
+        if (!isInternalCall) {
+          retryMap.delete(key)
           queryEntry.ext.isRetrying.value = false
           queryEntry.ext.retryCount.value = 0
           queryEntry.ext.retryError.value = null
-          retryMap.delete(key)
           if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
             queryEntry.ext.retry.isRetrying = false
             queryEntry.ext.retry.retryCount = 0
             queryEntry.ext.retry.retryError = null
           }
         }
+
+        // capture state before the fetch runs so we can revert during retries
+        const previousState = queryEntry.state.value
+
+        const retryFetch = () => {
+          if (queryEntry.state.value.status === 'error') {
+            const error = queryEntry.state.value.error
+            // ensure the entry exists
+            let entry = retryMap.get(key)
+            if (!entry) {
+              entry = { retryCount: 0 }
+              retryMap.set(key, entry)
+            }
+
+            const shouldRetry =
+              typeof retry === 'number' ? retry > entry.retryCount : retry(entry.retryCount, error)
+
+            if (shouldRetry) {
+              queryEntry.ext.isRetrying.value = true
+              queryEntry.ext.retryCount.value = entry.retryCount + 1
+              queryEntry.ext.retryError.value = error
+              if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
+                queryEntry.ext.retry.isRetrying = true
+                queryEntry.ext.retry.retryCount = entry.retryCount + 1
+                queryEntry.ext.retry.retryError = error
+              }
+              // revert to pre-fetch state so the error is only visible via retryError
+              queryEntry.state.value = previousState
+              const delayTime = typeof delay === 'function' ? delay(entry.retryCount) : delay
+              entry.timeoutId = setTimeout(() => {
+                if (!queryEntry.active || toValue(queryEntry.options?.enabled) === false) {
+                  retryMap.delete(key)
+                  queryEntry.ext.isRetrying.value = false
+                  queryEntry.ext.retryCount.value = 0
+                  queryEntry.ext.retryError.value = null
+                  if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
+                    queryEntry.ext.retry.isRetrying = false
+                    queryEntry.ext.retry.retryCount = 0
+                    queryEntry.ext.retry.retryError = null
+                  }
+                  return
+                }
+                // NOTE: we could add some default error handler
+                isInternalCall = true
+                Promise.resolve(queryCache.fetch(queryEntry)).catch(
+                  process.env.NODE_ENV !== 'test' ? console.error : () => {},
+                )
+                isInternalCall = false
+                if (entry) {
+                  entry.retryCount++
+                }
+              }, delayTime)
+            } else {
+              // remove the entry if we are not going to retry
+              queryEntry.ext.isRetrying.value = false
+              queryEntry.ext.retryError.value = null
+              retryMap.delete(key)
+              if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
+                queryEntry.ext.retry.isRetrying = false
+                queryEntry.ext.retry.retryError = null
+              }
+            }
+          } else {
+            // remove the entry if it worked out to reset it
+            queryEntry.ext.isRetrying.value = false
+            queryEntry.ext.retryCount.value = 0
+            queryEntry.ext.retryError.value = null
+            retryMap.delete(key)
+            if (process.env.NODE_ENV === 'development' && queryEntry.ext.retry) {
+              queryEntry.ext.retry.isRetrying = false
+              queryEntry.ext.retry.retryCount = 0
+              queryEntry.ext.retry.retryError = null
+            }
+          }
+        }
+        onError(retryFetch)
+        after(retryFetch)
       }
-      onError(retryFetch)
-      after(retryFetch)
     })
   }
 }

--- a/plugins/retry/src/retry.ts
+++ b/plugins/retry/src/retry.ts
@@ -98,6 +98,25 @@ export function PiniaColadaRetry(
         }
       }
 
+      // cleanup any pending retry when the user cancels the query
+      if (name === 'cancel') {
+        const [cacheEntry] = args
+        const key = cacheEntry.keyHash
+        const entry = retryMap.get(key)
+        if (entry) {
+          clearTimeout(entry.timeoutId)
+          retryMap.delete(key)
+        }
+        cacheEntry.ext.isRetrying.value = false
+        cacheEntry.ext.retryCount.value = 0
+        cacheEntry.ext.retryError.value = null
+        if (process.env.NODE_ENV === 'development' && cacheEntry.ext.retry) {
+          cacheEntry.ext.retry.isRetrying = false
+          cacheEntry.ext.retry.retryCount = 0
+          cacheEntry.ext.retry.retryError = null
+        }
+      }
+
       if (name !== 'fetch') return
       const [queryEntry] = args
       const localOptions = queryEntry.options?.retry


### PR DESCRIPTION
## Summary

`plugins/retry` doesn't respond to the `cancel` action. After a failed query, the plugin schedules a `setTimeout` for the next attempt. If the user calls `queryCache.cancel(entry)` between retries, the timer keeps ticking — when it fires, it dispatches a new fetch against the user's explicit cancel.

## The bug

The `$onAction` subscriber handles `extend`, `remove`, and `fetch`. `cancel` is missing.

1. Fetch fails → `onError(retryFetch)` schedules `setTimeout(..., delay)`, stores `timeoutId` in `retryMap`, sets `isRetrying=true` / `retryCount=N` / `retryError=e` on `entry.ext`.
2. No in-flight request between retries — just the timer.
3. User calls `queryCache.cancel(entry)`. `cancel` in `src/query-store.ts:754` aborts `entry.pending` (nothing pending) and nulls it. It does not touch `retryMap` or the plugin's `ext` refs.
4. Timer fires. Guard at `retry.ts:164` checks `entry.active` and `options.enabled` — both still truthy, `cancel` doesn't deactivate. Proceeds to `queryCache.fetch(queryEntry)` — the zombie request.

Symptom: the UI shows the cancel as "taken," then a mystery network call fires `delay` ms later and may even update the query's data.

## Fix

Add a `cancel` handler that mirrors `remove`'s `retryMap` cleanup, plus resets the reactive UI refs. Unlike `remove`, the cache entry survives `cancel`, so the `isRetrying` / `retryCount` / `retryError` refs — still observed by any mounted component — need to be reset, otherwise the UI continues to show "retrying..." indefinitely.

## Regression tests

Two tests under `cancel behavior`:

- `does not fire the scheduled retry after queryCache.cancel()` — asserts the query fn is called exactly once after cancel, even after advancing timers past the retry window.
- `resets retry UI flags on cancel` — asserts `isRetrying=false`, `retryCount=0`, `retryError=null` after cancel.

Both fail on the pre-fix code and pass with the fix.

The `factory` helper now also returns `pinia` so tests can resolve `useQueryCache(pinia)` and call `cancel` on the entry. Existing tests using `const { wrapper } = factory(...)` are unaffected.

## Test plan

- [x] `pnpm -F @pinia/colada-plugin-retry exec vitest run` — 25/25 pass
- [x] Full library suite — 501 pass, 11 todo, 0 fail
- [x] `oxlint` clean (no new warnings)
- [x] `oxfmt --check` clean
- [x] Typecheck clean
- [x] Two-sided verification: revert fix → both new tests fail; restore → all pass

---

Created with assistance by Claude Code. Vetted/validated by Danny-Devs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelling or removing queries now clears scheduled retries and immediately resets all retry-related state (retry count, retry status, and error), preventing pending retries from running.

* **Tests**
  * Added tests that verify cancellation by key and by entry prevents scheduled retries and immediately resets retry-related UI/state flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->