### PR TITLE
fix(query-store): avoid false HMR invalidation when the same component mounts multiple times

### DIFF
--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -143,9 +143,13 @@ export interface UseQueryEntry<
    */
   __hmr?: {
     /**
-     * Reference count of the components using this query.
+     * Per-hmrId tracking: reference count of mounted components and the last seen
+     * `render` function. A real HMR update replaces the component's `render`
+     * reference, so a changed reference signals an actual code update (and
+     * warrants invalidation), while an unchanged reference means a legitimate
+     * new instance of the same component (no invalidation needed).
      */
-    ids: Map<string, number>
+    ids: Map<string, { count: number, render: unknown }>
   }
 }
 
@@ -403,11 +407,15 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
     // clear any HMR to avoid letting the set grow
     if (process.env.NODE_ENV !== 'production') {
       if ('type' in effect && '__hmrId' in effect.type && entry.__hmr) {
-        const count = (entry.__hmr.ids.get(effect.type.__hmrId) ?? 1) - 1
-        if (count > 0) {
-          entry.__hmr.ids.set(effect.type.__hmrId, count)
+        const existing = entry.__hmr.ids.get(effect.type.__hmrId as string)
+        const count = (existing?.count ?? 1) - 1
+        if (count > 0 && existing) {
+          entry.__hmr.ids.set(effect.type.__hmrId as string, {
+            count,
+            render: existing.render,
+          })
         } else {
-          entry.__hmr.ids.delete(effect.type.__hmrId)
+          entry.__hmr.ids.delete(effect.type.__hmrId as string)
         }
       }
     }
@@ -570,27 +578,34 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       }
 
       // during HMR, staleTime could be long and if we change the query function, the query won't trigger a refetch
-      // so we need to detect and trigger just in case
+      // so we need to detect and trigger just in case.
+      //
+      // We distinguish a real HMR update from a legitimate new instance of the
+      // same component (lists, virtualized tables, staged mounts, etc.) by
+      // comparing the identity of `type.render`: a real HMR swap replaces it
+      // with a new function, while a new instance keeps the same reference.
       if (process.env.NODE_ENV !== 'production') {
         const currentInstance = getCurrentInstance()
         if (currentInstance) {
           entry.__hmr ??= { ids: new Map() }
 
-          const id =
-            // @ts-expect-error: internal property
-            currentInstance.type?.__hmrId
+          const type = currentInstance.type as {
+            __hmrId?: string
+            render?: unknown
+          }
+          const id = type?.__hmrId
 
-          // FIXME: if the user mounts the same component multiple times, I think it makes sense to fix this
-          // because we could have the same component mounted multiple times with different props but inside of the same
-          // they use the same query (cache, centralized). This sholdn't invalidate the query
-          // we can fix it by storing the currentInstance.type.render (we need to copy the values because the
-          // type object gets reused and replaced in place). It's not clear if this will work with Vapor
           if (id) {
-            if (entry.__hmr.ids.has(id)) {
+            const existing = entry.__hmr.ids.get(id)
+            const currentRender = type.render
+            if (existing && existing.render !== currentRender) {
+              // real HMR: the render function reference changed → code was updated
               invalidate(entry)
             }
-            const count = (entry.__hmr.ids.get(id) ?? 0) + 1
-            entry.__hmr.ids.set(id, count)
+            entry.__hmr.ids.set(id, {
+              count: (existing?.count ?? 0) + 1,
+              render: currentRender,
+            })
           }
         }
       }

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -2328,14 +2328,15 @@ describe('useQuery', () => {
   })
 
   describe('hmr', () => {
-    it('always refetches on hmr', async () => {
+    it('refetches when the component render function is swapped (real HMR)', async () => {
       const query = vi.fn(async () => 42)
+      const setup = () => {
+        useQuery({ key: ['id'], query })
+        return {}
+      }
       const component = defineComponent({
         render: () => null,
-        setup() {
-          useQuery({ key: ['id'], query })
-          return {}
-        },
+        setup,
         // to simulate HMR, the HMR id is stable across remounts
         __hmrId: 'some-id',
       })
@@ -2345,10 +2346,49 @@ describe('useQuery', () => {
       // simulate the wait of things to settle but do not let staleTime pass
       await flushPromises()
 
-      mount(component, { global: { plugins: [pinia, PiniaColada] } })
+      // simulate an HMR update: same __hmrId, but the render function reference
+      // changes (as Vite's HMR runtime does when the component's code updates).
+      const updatedComponent = defineComponent({
+        render: () => null,
+        setup,
+        __hmrId: 'some-id',
+      })
+      mount(updatedComponent, { global: { plugins: [pinia, PiniaColada] } })
       w1.unmount()
       await flushPromises()
       expect(query).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not refetch when the same component is mounted multiple times (list/grid scenario)', async () => {
+      const query = vi.fn(async () => 42)
+      const component = defineComponent({
+        render: () => null,
+        setup() {
+          useQuery({ key: ['shared'], query })
+          return {}
+        },
+        __hmrId: 'stable-id',
+      })
+
+      const pinia = createPinia()
+
+      // mount the same component 7 times, staggered across ticks — simulates
+      // a list/virtualized grid where rows mount one by one (pending fetch of
+      // the first instance should be reused by the rest).
+      const wrappers = []
+      for (let i = 0; i < 7; i++) {
+        wrappers.push(mount(component, { global: { plugins: [pinia, PiniaColada] } }))
+        // allow the pending fetch to start before the next instance mounts
+        await vi.advanceTimersByTimeAsync(10)
+      }
+
+      await flushPromises()
+
+      // all 7 instances share the same query key and the same render reference,
+      // so only one fetch should have happened — dedup must hold.
+      expect(query).toHaveBeenCalledTimes(1)
+
+      wrappers.forEach((w) => w.unmount())
     })
   })
 


### PR DESCRIPTION
Closes #569.

## Summary

In dev, `queryCache.ensure` invalidated a cache entry whenever the same `__hmrId` registered against it — which also fires when the same component is legitimately mounted multiple times (lists, virtualized grids, staged mounts). The existing `FIXME` / `TODO` comments in `src/query-store.ts` already described this exact problem and hinted at the fix.

Distinguish a real HMR update from a new instance by tracking `type.render`: HMR swaps the reference, a new instance keeps it.

## Changes

- `src/query-store.ts` — `__hmr.ids` stores `{ count, render }`; `invalidate(entry)` fires only when `render` reference changes.
- `src/use-query.spec.ts`:
  - Replaced `it('always refetches on hmr', ...)` — it asserted the old buggy behavior. Now simulates a real code swap (new `render`, same `__hmrId`) and still asserts 2 fetches.
  - Added a test for the repro from #569: 7 staggered mounts → 1 fetch.

## Verification

- New test fails on `main` (7 calls), passes with the fix (1 call).
- `use-query` + `query-store` + `define-query`: 163 passed, no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Hot Module Replacement detection to properly distinguish between actual code updates and new component instances, ensuring queries are only refetched when necessary.
  * Enhanced query request deduplication for multiple simultaneous component mounts of the same component, reducing redundant fetches and improving performance in list/grid scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->