### PR TITLE
refactor(tests): harden type tests for TS 7.0 (tsgo) error-span changes

### DIFF
--- a/src/define-query-options.test-d.ts
+++ b/src/define-query-options.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest'
 import { useQuery } from './use-query'
 import { useQueryCache, defineQueryOptions } from '@pinia/colada'
-import type { EntryKeyTagged } from '@pinia/colada'
+import type { DefineQueryOptions, EntryKeyTagged } from '@pinia/colada'
 import type { ErrorDefault } from './types-extension'
 
 describe('typed query keys', () => {
@@ -115,12 +115,7 @@ describe('typed query keys', () => {
         initialData: () => 'YES',
       })
 
-      // @ts-expect-error: initialData must be a function
-      defineQueryOptions({
-        key,
-        query,
-        initialData: 'YES',
-      })
+      expectTypeOf<'YES'>().not.toExtend<DefineQueryOptions<string>['initialData']>()
     })
 
     it('preserves initialData type', async () => {
@@ -332,12 +327,7 @@ describe('typed query keys', () => {
     })
 
     it('disallows function in meta', () => {
-      // @ts-expect-error: meta cannot be a function
-      defineQueryOptions({
-        key: ['a'],
-        query: async () => 'ok',
-        meta: () => ({}),
-      })
+      expectTypeOf<() => {}>().not.toExtend<DefineQueryOptions['meta']>()
 
       defineQueryOptions({
         key: ['a'],

--- a/src/define-query.test-d.ts
+++ b/src/define-query.test-d.ts
@@ -18,11 +18,7 @@ describe('defineQuery types', () => {
   })
 
   it('does not allow refs or getters in the key', () => {
-    // @ts-expect-error: key must be a direct value
-    defineQuery({
-      key: () => ['todos'],
-      query: async () => [{ id: 1 }],
-    })
+    expectTypeOf<() => readonly ['todos']>().not.toExtend<DefineQueryOptions['key']>()
   })
 
   it('can define a query with a function', () => {

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -55,7 +55,7 @@ describe('useInfiniteQuery', () => {
           async ({
             pageParam,
           }: UseInfiniteQueryFnContext<
-            UseInfiniteQueryData<TData, TPageParam>,
+            UseInfiniteQueryData<unknown, TPageParam>,
             TError,
             TDataInitial,
             TPageParam
@@ -85,7 +85,7 @@ describe('useInfiniteQuery', () => {
         render: () => null,
         setup() {
           queryCache = useQueryCache()
-          const useInfiniteQueryResult = useInfiniteQuery<TData, TError, TPageParam>({
+          const useInfiniteQueryResult = useInfiniteQuery<TData, TError, TPageParam, TDataInitial>({
             key: ['key'],
             initialPageParam: 0 as TPageParam,
             getNextPageParam(lastPage, allPages, lastPageParam, allPageParams) {
@@ -106,7 +106,6 @@ describe('useInfiniteQuery', () => {
               )
             },
             ...options,
-            // @ts-expect-error: it's fine
             query,
           })
           return {


### PR DESCRIPTION
## Summary

While experimenting with [TypeScript 7.0 beta (`tsgo`)](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/), 21 type errors appeared that are not present under `tsc` 6.0.3. Investigation showed:

- **13 errors** were due to a documented-and-WONTFIX error-span difference: when a `TS2769` overload mismatch occurs on an object literal argument, `tsc` reports at the call site, `tsgo` at the offending property ([microsoft/typescript-go#1088](https://github.com/microsoft/typescript-go/issues/1088)). Any `@ts-expect-error` placed above the `defineQuery({...})` call instead of next to the specific property becomes "unused" under `tsgo`.
- **8 errors** turned out to mask a real type inconsistency in the `infinite-query` test scaffolding. The `@ts-expect-error: it's fine` was hiding that the mock `query`'s context type used `UseInfiniteQueryData<TData, TPageParam>`, while `UseInfiniteQueryOptions.query` declares the context as `UseInfiniteQueryData<unknown, TPageParam>` (intentional — see the `NOTE` around `infinite-query.ts:56-59`, refs TS #49618 / #47599). Once the context is aligned and `TDataInitial` is forwarded as the 4th type argument to `useInfiniteQuery`, the directive isn't needed.

No runtime behavior changes. Both `tsc` 6 and `tsgo` 7.0-beta now pass clean.

## Changes

- `src/define-query.test-d.ts`, `src/define-query-options.test-d.ts`: three `@ts-expect-error` blocks over multi-line `defineQuery` / `defineQueryOptions` calls replaced with `expectTypeOf<...>().not.toExtend<...>()` assertions. Intent is clearer and independent of compiler error-span choices. Verified each assertion fails when inverted (i.e. they still prove what the old test proved).
- `src/infinite-query.spec.ts`: fix the mock context to use `UseInfiniteQueryData<unknown, TPageParam>`, forward `TDataInitial` to `useInfiniteQuery`, remove the now-unnecessary `@ts-expect-error`.

## Test plan

- [x] `pnpm test:types` (tsc 6.0.3) passes
- [x] `pnpm exec vitest run src/infinite-query.spec.ts` — 51/51 pass
- [ ] Optional: `pnpm add -D @typescript/native-preview@beta && node_modules/.bin/tsgo --build ./tsconfig.json` passes clean (locally verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced type validation tests with improved assertion patterns for better TypeScript type checking accuracy across query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->