### PR TITLE
fix(infinite-query): respect global query options

### DIFF
--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -123,6 +123,45 @@ describe('useInfiniteQuery', () => {
     return { wrapper, query, pinia, queryCache }
   }
 
+  describe('global query options', () => {
+    it('respects refetchOnWindowFocus from PiniaColada plugin defaults', async () => {
+      const query = vi.fn(async ({ pageParam }: { pageParam: number }) => [pageParam])
+      const wrapper = mount(
+        defineComponent({
+          render: () => null,
+          setup() {
+            return {
+              ...useInfiniteQuery({
+                key: ['global-options'],
+                initialPageParam: 0,
+                getNextPageParam: () => null,
+                query,
+              }),
+            }
+          },
+        }),
+        {
+          global: {
+            plugins: [
+              createPinia(),
+              [PiniaColada, { queryOptions: { refetchOnWindowFocus: 'always' } }],
+            ],
+          },
+        },
+      )
+
+      await flushPromises()
+      expect(query).toHaveBeenCalledTimes(1)
+
+      document.dispatchEvent(new Event('visibilitychange'))
+      await flushPromises()
+
+      expect(query).toHaveBeenCalledTimes(2)
+
+      wrapper.unmount()
+    })
+  })
+
   it('appends data when fetching next pages', async () => {
     const { wrapper } = mountSimple()
 

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -471,16 +471,10 @@ export function useInfiniteQuery<
           return { pages, pageParams }
         },
 
-        // other options that need to be normalized
         meta: {
           ...toValue(opts.meta),
           __i: 1,
         },
-        // enabled: toValue(opts.enabled),
-        refetchOnMount: toValue(opts.refetchOnMount),
-        refetchOnReconnect: toValue(opts.refetchOnReconnect),
-        refetchOnWindowFocus: toValue(opts.refetchOnWindowFocus),
-        // initialData: toValue(opts.initialData),
       }
       // satisfies DefineQueryOptions<UseInfiniteQueryData<TData, TPageParam>, TError, TDataInitial>
     },


### PR DESCRIPTION
## Summary
- `useInfiniteQuery` was eagerly normalizing `refetchOnMount` / `refetchOnReconnect` / `refetchOnWindowFocus` inside the getter passed to `useQuery`. When the user did not set them, `toValue()` returned `undefined` and clobbered the plugin-provided defaults during `useQuery`'s `{ ...optionDefaults, ...userOpts }` merge.
- Removed the redundant normalizations — `useQuery` already unwraps these lazily at their usage sites.

Fixes #574

## Test plan
- [x] New regression test in `src/infinite-query.spec.ts` (`global query options > respects refetchOnWindowFocus from PiniaColada plugin defaults`) — fails before the fix, passes after.
- [x] Full suite: `pnpm exec vitest run` — 499 passed, 11 todo, no type errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for global refetch-on-window-focus behavior in infinite queries.

* **Refactor**
  * Simplified query option handling by deferring refetch behavior configuration to the underlying query mechanism instead of duplicating logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->