### PR TITLE
docs: fix TypeScript capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Pinia Colada makes data fetching in Vue applications a breeze. It's built on top
 - ✨ **Optimistic Updates**: UI that updates before the server responds
 - 💡 **Sensible defaults**: Works well out of the box while remaining fully configurable
 - 🧩 **Out-of-the box plugins**: Auto refetch, delay loading, and more
-- 📚 **Typescript Support**: Best-in-class TypeScript support
+- 📚 **TypeScript Support**: Best-in-class TypeScript support
   <!-- - 📡 **Network Status**: Handle network status and offline support -->
   <!-- - 🛠 **Devtools**: Integration with the Vue devtools -->
 - 💨 **Small Bundle Size**: A baseline of ~2kb and fully tree-shakeable


### PR DESCRIPTION
"Typescript" should be "TypeScript" — the official capitalization per the TypeScript team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected TypeScript branding in README.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/posva/pinia-colada/pull/588)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->