### PR TITLE
fix(infinite-query): store nextPageIndicator on entry.ext instead of closure

### DIFF
--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -658,6 +658,106 @@ describe('useInfiniteQuery', () => {
     })
   })
 
+  it('loadNextPage continues from the last page across multiple components sharing the same key', async () => {
+    const pinia = createPinia()
+
+    const query = vi.fn(async ({ pageParam }: { pageParam: number }) => {
+      return [pageParam * 3 + 1, pageParam * 3 + 2, pageParam * 3 + 3] as number[]
+    })
+
+    const sharedOptions = {
+      key: ['shared-key'],
+      query,
+      initialPageParam: 0,
+      getNextPageParam: (_lastPage: number[], _allPages: number[][], lastPageParam: number) =>
+        lastPageParam + 1,
+    }
+
+    let queryA!: ReturnType<typeof useInfiniteQuery>
+    let queryB!: ReturnType<typeof useInfiniteQuery>
+
+    const ComponentA = defineComponent({
+      setup() {
+        queryA = useInfiniteQuery(sharedOptions)
+      },
+      render: () => null,
+    })
+
+    const ComponentB = defineComponent({
+      setup() {
+        queryB = useInfiniteQuery(sharedOptions)
+      },
+      render: () => null,
+    })
+
+    const showComponentB = ref(false)
+
+    // Mount both in the same app so they share the same pinia/queryCache. Component B is initially hidden.
+    mount(
+      defineComponent({
+        components: { ComponentA, ComponentB },
+        render() {
+          return [h(ComponentA), showComponentB.value ? h(ComponentB) : null]
+        },
+      }),
+      { global: { plugins: [pinia, PiniaColada] } },
+    )
+
+    await flushPromises()
+
+    expect(queryA.data.value).toEqual({ pages: [[1, 2, 3]], pageParams: [0] })
+
+    // Load next page from component A.
+    await queryA.loadNextPage()
+
+    expect(queryA.data.value).toEqual({
+      pages: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      pageParams: [0, 1],
+    })
+
+    // Show component B, it should have the same data without refetching since it shares the same key and query cache.
+    showComponentB.value = true
+    await nextTick()
+    query.mockClear()
+
+    expect(queryB.data.value).toEqual({
+      pages: [
+        [1, 2, 3],
+        [4, 5, 6],
+      ],
+      pageParams: [0, 1],
+    })
+
+    expect(query).toHaveBeenCalledTimes(0)
+
+    // Load next page from component B, should continue from the same pageParam and update both A and B.
+    await queryB.loadNextPage()
+
+    expect(query).toHaveBeenCalledTimes(1)
+    expect(query).toHaveBeenCalledWith(expect.objectContaining({ pageParam: 2 }))
+
+    expect(queryA.data.value).toEqual({
+      pages: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      pageParams: [0, 1, 2],
+    })
+
+    expect(queryB.data.value).toEqual({
+      pages: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ],
+      pageParams: [0, 1, 2],
+    })
+  })
+
   it('sets hasNextPage to false if getNextPageParam returns null', async () => {
     const { wrapper } = mountSimple({
       getNextPageParam: (lastPage, allPages, lastPageParam) => {

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -202,6 +202,13 @@ type UseInfiniteQueryExtensions<TPageParam> = Pick<
    * @internal
    */
   previousPageParam: ShallowRef<TPageParam | null | undefined>
+
+  /**
+   * The next page that will be loaded: 0 for all pages, 1 for next page, and -1 for previous page
+   *
+   * @internal
+   */
+  nextPageIndicator: NextPageIndicator
 }
 
 /**
@@ -236,6 +243,7 @@ function PiniaColadaInfiniteQueryPlugin(scope: EffectScope, queryCache: QueryCac
             entry.ext.hasNextPage = hasNextPage
             entry.ext.previousPageParam = previousPageParam
             entry.ext.hasPreviousPage = hasPreviousPage
+            entry.ext.nextPageIndicator = 0
           })
         }
       }
@@ -257,6 +265,7 @@ function createInfiniteQueryEntryExtensions(extensions: UseInfiniteQueryExtensio
   extensions.hasNextPage = computed(() => extensions.nextPageParam.value != null)
   extensions.previousPageParam = shallowRef<unknown | null | undefined>()
   extensions.hasPreviousPage = computed(() => extensions.previousPageParam.value != null)
+  extensions.nextPageIndicator = 0
 }
 
 /**
@@ -336,8 +345,6 @@ export function useInfiniteQuery<
   const queryCache = useQueryCache()
   // adds hasNextPage and hasPreviousPage to the entry when it's created in the cache
   PiniaColadaInfiniteQueryPlugin(queryCache._s, queryCache)
-  // we start by assuming we want to load the next page
-  let nextPage: NextPageIndicator = 0
 
   let entry:
     | UseQueryEntry<UseInfiniteQueryData<TData, TPageParam>, TError, TDataInitial>
@@ -371,16 +378,16 @@ export function useInfiniteQuery<
             (state.status === 'pending' ||
               // edge case: data is empty, we want to fetch normally
               !data?.pages.length) &&
-            !nextPage
+            !exts.nextPageIndicator
           ) {
-            nextPage = 1
+            exts.nextPageIndicator = 1
           }
 
-          const position = nextPage > 0 ? -1 : 0
+          const position = exts.nextPageIndicator > 0 ? -1 : 0
 
           // the status was not pending so this is a manual refetch
           if (
-            !nextPage &&
+            !exts.nextPageIndicator &&
             // NOTE: at this point data cannot be undefined but this makes TS happy
             data
           ) {
@@ -414,7 +421,7 @@ export function useInfiniteQuery<
               }
             }
           } else {
-            nextPage = 0
+            exts.nextPageIndicator = 0
 
             if (process.env.NODE_ENV !== 'production') {
               if (position === 0 && !opts.getPreviousPageParam) {
@@ -531,7 +538,7 @@ export function useInfiniteQuery<
       return entry.pending.refreshCall
     }
 
-    nextPage = page
+    ;(entry.ext as unknown as UseInfiniteQueryExtensions<TPageParam>).nextPageIndicator = page
 
     return queryCache.fetch(entry).catch(throwOnError ? undefined : noop)
   }


### PR DESCRIPTION
As I brought up in #589, I believe this could be a bug. I took a swing at it with a new test where I was able to reproduce the issue.

Essentially, the local next page indicator causes issues when the same query is mounted more than once. I've instead moved that indicator onto the cache entry so it can be shared between queries with the same key.

Cheers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test coverage to verify pagination continues correctly when multiple components share the same query cache.

* **Refactor**
  * Improved internal state tracking for multi-page query loading to ensure consistent behavior across shared component instances.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/posva/pinia-colada/pull/590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->