### PR TITLE
test(retry): cover stuck pending state after abandoned retry

### DIFF
--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -689,4 +689,45 @@ describe('Pinia Colada Retry Plugin', () => {
     expect(wrapper.vm.retryCount).toBe(0)
     expect(wrapper.vm.retryError).toBeNull()
   })
+
+  it('refetches after a scheduled retry is abandoned by unmount', async () => {
+    const query = vi.fn(async () => {
+      throw new Error('ko')
+    })
+  
+    const { wrapper, pinia } = factory({ key: ['key'], query })
+  
+    // Initial fetch fails; retry plugin schedules a retry.
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  
+    // Unmount before the retry fires — the scheduled callback will
+    // bail on `!entry.active` without refetching.
+    wrapper.unmount()
+    vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(1)
+  
+    // Entry is pending with no data; must read as stale so a remount's
+    // `refresh()` triggers a fetch.
+    const queryCache = useQueryCache(pinia)
+    const entry = queryCache.getEntries({ key: ['key'] })[0]!
+    expect(entry.state.value.status).toBe('pending')
+    expect(entry.state.value.data).toBeUndefined()
+    expect(entry.stale).toBe(true)
+  
+    // Remount with the same key — should refetch.
+    mount(
+      defineComponent({
+        template: '<div></div>',
+        setup() {
+          return useQuery({ key: ['key'], query })
+        },
+      }),
+      { global: { plugins: [pinia, [PiniaColada, { plugins: [PiniaColadaRetry(RETRY_OPTIONS_DEFAULTS)] }]] } },
+    )
+  
+    await flushPromises()
+    expect(query).toHaveBeenCalledTimes(2)
+  })
 })

--- a/plugins/retry/src/retry.spec.ts
+++ b/plugins/retry/src/retry.spec.ts
@@ -690,24 +690,24 @@ describe('Pinia Colada Retry Plugin', () => {
     expect(wrapper.vm.retryError).toBeNull()
   })
 
-  it('refetches after a scheduled retry is abandoned by unmount', async () => {
+  it.todo('refetches after a scheduled retry is abandoned by unmount', async () => {
     const query = vi.fn(async () => {
       throw new Error('ko')
     })
-  
+
     const { wrapper, pinia } = factory({ key: ['key'], query })
-  
+
     // Initial fetch fails; retry plugin schedules a retry.
     await flushPromises()
     expect(query).toHaveBeenCalledTimes(1)
-  
+
     // Unmount before the retry fires — the scheduled callback will
     // bail on `!entry.active` without refetching.
     wrapper.unmount()
     vi.advanceTimersByTime(RETRY_OPTIONS_DEFAULTS.delay)
     await flushPromises()
     expect(query).toHaveBeenCalledTimes(1)
-  
+
     // Entry is pending with no data; must read as stale so a remount's
     // `refresh()` triggers a fetch.
     const queryCache = useQueryCache(pinia)
@@ -715,7 +715,7 @@ describe('Pinia Colada Retry Plugin', () => {
     expect(entry.state.value.status).toBe('pending')
     expect(entry.state.value.data).toBeUndefined()
     expect(entry.stale).toBe(true)
-  
+
     // Remount with the same key — should refetch.
     mount(
       defineComponent({
@@ -724,9 +724,13 @@ describe('Pinia Colada Retry Plugin', () => {
           return useQuery({ key: ['key'], query })
         },
       }),
-      { global: { plugins: [pinia, [PiniaColada, { plugins: [PiniaColadaRetry(RETRY_OPTIONS_DEFAULTS)] }]] } },
+      {
+        global: {
+          plugins: [pinia, [PiniaColada, { plugins: [PiniaColadaRetry(RETRY_OPTIONS_DEFAULTS)] }]],
+        },
+      },
     )
-  
+
     await flushPromises()
     expect(query).toHaveBeenCalledTimes(2)
   })


### PR DESCRIPTION
failing test case for https://github.com/posva/pinia-colada/issues/592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test validating retry behavior when a component unmounts before a scheduled retry and later remounts: ensures no extra fetch runs while unmounted, the cached request remains pending/stale during unmount, and remounting triggers a fresh fetch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/posva/pinia-colada/pull/593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->