### PR TITLE
feat: nostics migration — Opus

### DIFF
--- a/.claude/skills/nostics-migration/SKILL.md
+++ b/.claude/skills/nostics-migration/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: nostics-migration
+description: Migrate a library's user-facing errors, warnings, and logs to nostics diagnostics. Use when replacing console.warn/console.error, warn() helpers, or thrown Errors with stable diagnostic codes, or when designing or extending a defineDiagnostics catalog.
+---
+
+# Migrate errors and warnings to nostics
+
+Turn ad hoc warnings and errors into a catalog of stable diagnostic codes **without changing runtime behavior**. API details: `references/nostics-api.md`.
+
+## What to migrate
+
+Inventory `console.warn`, `console.error`, `warn(...)` helpers, `throw new Error(...)`, `Promise.reject(new Error(...))`. Skip tests, fixtures, snapshots, and generated output. Plain debug `console.log`s are usually not user-facing; leave them.
+
+Migrate:
+
+- dev warnings that report and keep going
+- warnings followed by recovery or a fallback (replace only the report, keep the recovery)
+- plain user-facing thrown or rejected `Error`s (the diagnostic becomes the thrown/rejected value)
+- deprecation notices
+- build/config errors caused by a user's file: always pass **both** the original error as `cause` and the file as `sources`, because the JS stack points inside the library and is useless to the user
+
+Do **not** migrate:
+
+- **structured errors other code inspects** (type fields, private symbols, `isXxxError()` guards, `instanceof` checks): they are control flow, not reporting. Leave them unchanged. Only if such an error is also deliberately user-facing, add a separate dev-only report with the error as `cause`; never replace the error object itself.
+- **catch blocks that only log a native/platform error and fall back** when the library cannot name a likely cause or a concrete fix: the native error is the best available information, keep the plain log. This exception covers platform APIs failing (e.g. `history.pushState`, storage quota), **not** errors caused by the user's own files: a caught parse or config error on a user file should become a diagnostic carrying the original error as `cause` and the file as `sources`.
+- anything where the diagnostic would only restate "an operation failed". A diagnostic earns its place by naming a likely user-code problem or a concrete fix.
+
+## Preserve behavior exactly
+
+A project's dev guard may be `process.env.NODE_ENV !== 'production'` or its own build-time constant (libraries often define a flag for this; recognize whatever the codebase uses). Written as `DEV` below; treat all forms the same:
+
+- Keep existing dev guards exactly as they are. nostics stripping is additive and does not replace them. If a throw or reject only happened in dev, it must still only happen in dev.
+- Never add a guard the original did not have. A throw or report that fired in production keeps firing in production builds that do not use stripping; note that migrating an unguarded report-only call makes it strippable, so once `nosticsStrip` runs in the build it disappears from production bundles. That is usually the goal of the migration, but if the library deliberately reports in production, surface that decision instead of changing it silently.
+- Keep throw vs reject, timing, recovery code, and returned fallbacks.
+- Keep structured error shapes (fields, symbols). Migrating a throw replaces the thrown message with the diagnostic's `why`: if tests assert the exact old text, update them deliberately as part of the migration, never weaken the message to dodge a test.
+
+## Catalog shape
+
+One catalog file per area of the library (a single `src/diagnostics.ts` is fine for small ones), exported directly. No factory wrappers and no deep barrel re-exports: the strip plugin tracks the export across one relative import. `nostics` is a runtime import: add it to `dependencies`, not `devDependencies` (library bundlers refuse or inline it otherwise).
+
+```ts
+import { createConsoleReporter, defineDiagnostics } from 'nostics'
+
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: (code) => `https://example.com/e/${code.toLowerCase()}`,
+  reporters: [/*#__PURE__*/ createConsoleReporter()],
+  codes: {
+    LIB_R0001: {
+      why: (p: { hook: string }) => `${p.hook}() must be called at the top of a setup function.`,
+      fix: 'Move the call into setup() or a composable called by setup().',
+    },
+  },
+})
+```
+
+- Codes are `PREFIX_XNNNN`. Pick the category letter by **area**, not severity: `B` build, `R` runtime, `C` config, `D` deprecation. A runtime warning is `R`; reserve `D` for deprecations. Published codes are permanent: never rename or reuse one.
+- `why` says what happened with runtime values interpolated through typed param functions (both `why` and `fix` accept them; their params are merged and required at the call site). `fix` is the concrete next action, never a restatement of the problem.
+- Extra `console.warn`/`console.error` arguments must not be lost: an error value becomes `cause`; data values are interpolated into `why` (e.g. `JSON.stringify(p.value)`).
+- `cause` and `sources` (`'file:line:column'` strings pointing at user code) go **inside the params object** (the first argument), merged with the message params. The second argument is reporter options only, e.g. `{ method: 'error' }`.
+- `docsBase` is optional. If the project has no documented error-page URL scheme, propose one and surface it to the maintainer rather than inventing pages that do not exist.
+
+## Call-site patterns
+
+| Before                                      | After                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `DEV && warn(msg)`                          | `DEV && diagnostics.LIB_R0001(params)` (same guard)                                                    |
+| warn, then recover/fallback                 | diagnostic, then the same recovery                                                                     |
+| warn, then `throw new Error(...)`           | `throw diagnostics.LIB_R0002(params)`                                                                  |
+| warn, then `Promise.reject(new Error(...))` | `return Promise.reject(diagnostics.LIB_R0003(params))`                                                 |
+| `console.error(...)` level                  | `diagnostics.LIB_B0001(params, { method: 'error' })`                                                   |
+| caught error tied to a user file            | `diagnostics.LIB_B0002({ ...params, cause: err, sources: ['src/file.ts:10:5'] }, { method: 'error' })` |
+| structured/internal error                   | leave unchanged                                                                                        |
+
+Calling a handle always runs the reporters, so `throw diagnostics.CODE(params)` reports **and** throws. For a warn-then-throw site that is the same double output it already had; for a bare `throw new Error(...)` it adds a console report before the throw, which is normally fine but worth mentioning if the library is strict about console output.
+
+Report-only calls must stay bare expression statements (`DEV && diagnostics.LIB_R0001(p)` included) so `nosticsStrip` can remove them in production. `throw`/`return`/assigned diagnostics are behavior and stay.
+
+Dropping diagnostics from production builds takes two pieces: `/*#__PURE__*/` annotations on the catalog (`defineDiagnostics(...)` and each reporter factory call inside it) so an unused catalog tree-shakes away, and a `DEV` guard on every report-only call site. Both can be written manually in source, or the `nosticsStrip` build plugin adds them at build time (`import { nosticsStrip } from 'nostics/unplugin/strip-transform'`, then the matching unplugin adapter: `nosticsStrip.rolldown()`, `.vite()`, `.rollup()`, ...). Decide from context: when every report-only site is already dev-guarded, manual annotations in the catalog file are enough and avoid a build transform; reach for the plugin when call sites are unguarded and stripping is wanted. Either way the behavior rule holds: if the library deliberately reports unguarded in production, do not silence it with a guard or the plugin; ask the maintainer.
+
+## Verify
+
+- Tests for warnings, throws, guards, and error shapes still pass; tests asserting exact message text are updated consciously, not accidentally.
+- Dev-only gates are still present everywhere the source had them, and no new gates were added.
+- Report-only diagnostics remain strippable expression statements. Thrown/returned diagnostics keep their message text in production by design: they are behavior, not reports.

--- a/.claude/skills/nostics-migration/references/nostics-api.md
+++ b/.claude/skills/nostics-migration/references/nostics-api.md
@@ -1,0 +1,121 @@
+# nostics API cheat sheet
+
+Accurate as of nostics 0.4 (https://www.npmjs.com/package/nostics).
+
+## Core
+
+```ts
+import { createConsoleReporter, defineDiagnostics, Diagnostic } from 'nostics'
+```
+
+`defineDiagnostics({ docsBase?, reporters?, codes })` returns one callable handle per code. Calling a handle creates a fresh `Diagnostic`, runs every reporter in order, and returns the instance. `throw` the return value to raise it — reporters still run first, so a thrown diagnostic also reports.
+
+`Diagnostic extends Error`:
+
+- `name`: the code (e.g. `LIB_R0001`)
+- `message` / `why`: resolved explanation
+- `fix?`: how to resolve it
+- `docs?`: docs URL
+- `sources?`: `'file:line:column'` strings from the call site
+- `cause?`: original error from the call site
+- `toJSON()`: `{ name, why, fix, docs, sources, cause, stack }` (all keys present; `JSON.stringify` drops the `undefined` ones later)
+
+## Definitions
+
+```ts
+export const diagnostics = defineDiagnostics({
+  docsBase: (code) => `https://example.com/e/${code.toLowerCase()}`,
+  reporters: [createConsoleReporter()],
+  codes: {
+    LIB_B2011: {
+      why: (p: { src: string; mode: 'client' | 'server' }) =>
+        `Plugin "${p.src}" conflicts with mode "${p.mode}".`,
+      fix: (p: { mode: 'client' | 'server' }) =>
+        `Rename the file or register it with mode "${p.mode === 'client' ? 'server' : 'client'}".`,
+      docs: 'https://example.com/custom', // optional per-code override, or `false` to omit
+    },
+  },
+})
+```
+
+- `why` is required (string or typed param function); it becomes `Error.message`.
+- `fix` is optional but recommended whenever the solution is known.
+- Params from `why` and `fix` are intersected and required (type-checked) at the call site.
+- `docsBase` as a string appends `/${code.toLowerCase()}`; as a function it receives the code and returns the full URL (or `undefined` to omit).
+
+## Call sites
+
+```ts
+diagnostics.LIB_B2011({ src, mode }) // report only — returns the Diagnostic
+throw diagnostics.LIB_B2011({ src, mode }) // raise
+
+// runtime fields merge into the same params object:
+diagnostics.LIB_B2011({
+  src,
+  mode,
+  cause: originalError,
+  sources: ['nuxt.config.ts:42:3'],
+})
+
+// reporter options are the second argument:
+diagnostics.LIB_B2011({ src, mode }, { method: 'error' })
+```
+
+`sources` matters most for build/config diagnostics where the JS stack points inside the library but the problem lives in a user file.
+
+## Reporters and formatters
+
+| Built-in                          | Import                    | Use                                                                                                                               |
+| --------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `createConsoleReporter(options?)` | `nostics`                 | `console[method](formatter(d))`; `method` defaults to `'warn'`, overridable per call via `{ method: 'log' \| 'warn' \| 'error' }` |
+| `createFileReporter(options?)`    | `nostics/reporters/node`  | NDJSON appended to `.nostics.log`                                                                                                 |
+| `createFetchReporter(url)`        | `nostics/reporters/fetch` | POSTs diagnostic JSON; failures swallowed                                                                                         |
+| `createDevReporter()`             | `nostics/reporters/dev`   | browser → Vite dev server via `import.meta.hot`                                                                                   |
+
+Formatters: `formatDiagnostic` (plain text, default), `ansiFormatter(colors)` from `nostics/formatters/ansi`, `jsonFormatter` from `nostics/formatters/json`.
+
+Custom reporter: `(diagnostic: Diagnostic, options?: Opts) => void`. Declaring a required `options` type makes the second call-site argument required and typed.
+
+Output shape of `formatDiagnostic`:
+
+```txt
+[LIB_B2011] Plugin `./analytics.server.ts` conflicts with mode `client`.
+├▶ fix: Rename the file or register it with the other mode.
+├▶ sources: modules/analytics.ts:18:5
+╰▶ see: https://example.com/e/lib_b2011
+```
+
+## Production stripping
+
+```ts
+import { nosticsStrip } from 'nostics/unplugin/strip-transform'
+// vite: nosticsStrip.vite()  — also .rollup() .rolldown() .webpack() .esbuild() ...
+```
+
+The plugin marks `defineDiagnostics()` as `/*#__PURE__*/` and wraps **bare diagnostic expression statements** with `process.env.NODE_ENV !== "production" &&` so bundlers drop them:
+
+```ts
+diagnostics.LIB_R0001() // strippable
+condition && diagnostics.LIB_R0002() // strippable
+```
+
+These stay, because they are behavior:
+
+```ts
+throw diagnostics.LIB_R0003()
+return diagnostics.LIB_R0004()
+const d = diagnostics.LIB_R0005()
+fn(diagnostics.LIB_R0006())
+```
+
+For the cross-file tracking to work: relative imports, export the `defineDiagnostics()` result directly, no factory wrappers, no deep barrels.
+
+Stripping is **additive**. It does not replace a library's own dev/prod compile-time guards (`process.env.NODE_ENV` checks or project-defined build-time constants); keep those guards unless the project deliberately changes its build strategy and verifies the bundle.
+
+The plugin is optional: writing `/*#__PURE__*/` manually before `defineDiagnostics(` and each reporter factory call, with every report-only call site dev-guarded in source, achieves the same production output without a build transform.
+
+Dev-time collection for apps: `nosticsCollector.vite()` from `nostics/unplugin/dev-server-collector` + `createDevReporter()` in the catalog reporters.
+
+## Docs registry
+
+Each published code should keep a stable URL forever. Page template: title with code, level, what happened, how to fix it, common causes, example output. A CI check can diff catalog keys against docs pages.

--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -274,6 +274,24 @@ On top of that Pinia Colada is highly extensible. You can create your own plugin
           ],
         },
         {
+          text: 'Diagnostics',
+          link: '/errors/',
+          items: [
+            { text: 'PC_R0001', link: '/errors/pc_r0001.html' },
+            { text: 'PC_R0002', link: '/errors/pc_r0002.html' },
+            { text: 'PC_R0003', link: '/errors/pc_r0003.html' },
+            { text: 'PC_R0004', link: '/errors/pc_r0004.html' },
+            { text: 'PC_R0005', link: '/errors/pc_r0005.html' },
+            { text: 'PC_R0006', link: '/errors/pc_r0006.html' },
+            { text: 'PC_R0007', link: '/errors/pc_r0007.html' },
+            { text: 'PC_R0008', link: '/errors/pc_r0008.html' },
+            { text: 'PC_R0009', link: '/errors/pc_r0009.html' },
+            { text: 'PC_R0010', link: '/errors/pc_r0010.html' },
+            { text: 'PC_R0011', link: '/errors/pc_r0011.html' },
+            { text: 'PC_R0012', link: '/errors/pc_r0012.html' },
+          ],
+        },
+        {
           text: 'Cookbook',
           link: '/cookbook/',
           items: [

--- a/docs/errors/index.md
+++ b/docs/errors/index.md
@@ -1,0 +1,45 @@
+# Diagnostics
+
+Pinia Colada reports user-facing problems through stable **diagnostic codes**. Each warning or error logged in development carries a code like `PC_R0003` and a link to a dedicated page explaining what happened and how to fix it.
+
+```txt
+[PC_R0003] useQuery() was called with an empty array as the key. It must have at least one element.
+├▶ fix: Provide a key with at least one element, e.g. ["todos"].
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0003
+```
+
+## How codes are structured
+
+Codes follow the pattern `PC_XNNNN`:
+
+- `PC` is the Pinia Colada prefix.
+- The letter is the **area** the diagnostic belongs to:
+  - `R` — runtime
+  - `C` — config
+  - `D` — deprecation
+- The number is a stable identifier. Published codes are permanent: a code is never renamed or reused.
+
+## Development vs production
+
+Most diagnostics are **development-only**: they are guarded so they do not run in production builds. Diagnostics that are part of behavior (the ones that `throw`) keep their message in production as well, but the report-only warnings are stripped out of optimized bundles.
+
+This means you should fix every diagnostic you see in development, even the ones that "only warn" — in production they are silent.
+
+## Catalog
+
+### Runtime
+
+| Code                       | Summary                                                           |
+| -------------------------- | ----------------------------------------------------------------- |
+| [`PC_R0001`](./pc_r0001)   | `useQueryCache()` called outside of an injection context          |
+| [`PC_R0002`](./pc_r0002)   | The query cache was reassigned instead of mutated                 |
+| [`PC_R0003`](./pc_r0003)   | `useQuery()` called with an empty array key                       |
+| [`PC_R0004`](./pc_r0004)   | `entry.refresh()` / `entry.fetch()` called without options        |
+| [`PC_R0005`](./pc_r0005)   | `defineMutation()` called outside of a component or effect scope  |
+| [`PC_R0006`](./pc_r0006)   | `useMutationCache()` called outside of an injection context       |
+| [`PC_R0007`](./pc_r0007)   | The mutation cache was reassigned instead of mutated              |
+| [`PC_R0008`](./pc_r0008)   | A mutation entry was mutated before being ensured                 |
+| [`PC_R0009`](./pc_r0009)   | A mutation entry was reused                                       |
+| [`PC_R0010`](./pc_r0010)   | `loadPreviousPage()` called without `getPreviousPageParam`        |
+| [`PC_R0011`](./pc_r0011)   | Infinite query entry not found in the cache                       |
+| [`PC_R0012`](./pc_r0012)   | `PiniaColada` installed without a Pinia instance                  |

--- a/docs/errors/pc_r0001.md
+++ b/docs/errors/pc_r0001.md
@@ -1,0 +1,41 @@
+# PC_R0001
+
+**Level:** warning (development only) · **Area:** runtime
+
+## What happened
+
+`useQueryCache()` was called outside of an injection context (a component `setup`, a store, or a navigation guard). Vue's `inject` only works during these contexts, so it will additionally emit its own warning about `inject` being used incorrectly.
+
+## How to fix it
+
+Call `useQueryCache()` only where injection is allowed:
+
+- inside a component `setup()`
+- inside a Pinia store setup
+- inside a Vue Router navigation guard
+- inside a composable that is itself called from one of the above
+
+```ts
+import { useQueryCache } from '@pinia/colada'
+
+function useThing() {
+  // ✅ called from a composable used in setup()
+  const queryCache = useQueryCache()
+  // ...
+}
+```
+
+If you genuinely need the cache outside of a component, pass the `pinia` instance explicitly: `useQueryCache(pinia)`.
+
+## Common causes
+
+- Calling `useQueryCache()` at module top-level.
+- Calling it inside an async callback after `await`, which loses the injection context.
+
+## Example output
+
+```txt
+[PC_R0001] useQueryCache() was called outside of an injection context (component setup, store, navigation guard). You will get a warning about "inject" being used incorrectly from Vue.
+├▶ fix: Make sure to use it only in allowed places. See https://vuejs.org/guide/reusability/composables.html#usage-restrictions
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0001
+```

--- a/docs/errors/pc_r0002.md
+++ b/docs/errors/pc_r0002.md
@@ -1,0 +1,34 @@
+# PC_R0002
+
+**Level:** error (development only) · **Area:** runtime
+
+## What happened
+
+The query cache `ref` was **reassigned** (e.g. `queryCache.caches.value = somethingElse`) instead of being mutated in place. The cache must keep the same underlying object so Pinia Colada and its plugins can track entries. Reassigning it would break in production.
+
+## How to fix it
+
+Mutate the existing cache rather than replacing it. Use the cache actions (`get`, `set`, `setQueryData`, `invalidateQueries`, etc.) instead of swapping out the internal map.
+
+```ts
+const queryCache = useQueryCache()
+
+// ❌ replaces the reactive value
+// queryCache.caches.value = new Map()
+
+// ✅ mutate through the public API
+queryCache.setQueryData(['todos'], [])
+```
+
+## Common causes
+
+- Resetting the cache with an assignment instead of the provided actions.
+- A devtools or test helper assigning to the internal ref.
+
+## Example output
+
+```txt
+[PC_R0002] The query cache cannot be directly set, it must be modified only.
+├▶ fix: Mutate the existing cache instead of reassigning it. This will fail in production.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0002
+```

--- a/docs/errors/pc_r0003.md
+++ b/docs/errors/pc_r0003.md
@@ -1,0 +1,36 @@
+# PC_R0003
+
+**Level:** error (thrown, development only) · **Area:** runtime
+
+## What happened
+
+`useQuery()` (or a related helper) was called with an **empty array** as its `key`. A query key must uniquely identify the query and therefore needs at least one element.
+
+## How to fix it
+
+Provide a key with at least one element:
+
+```ts
+import { useQuery } from '@pinia/colada'
+
+// ❌ empty key
+// useQuery({ key: [], query: getTodos })
+
+// ✅ at least one element
+useQuery({ key: ['todos'], query: getTodos })
+```
+
+If the key depends on a value that may be empty, guard the query with `enabled` or compute a non-empty key.
+
+## Common causes
+
+- A computed key that returns `[]` before its dependencies are ready.
+- Spreading an empty array into the key.
+
+## Example output
+
+```txt
+[PC_R0003] useQuery() was called with an empty array as the key. It must have at least one element.
+├▶ fix: Provide a key with at least one element, e.g. ["todos"].
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0003
+```

--- a/docs/errors/pc_r0004.md
+++ b/docs/errors/pc_r0004.md
@@ -1,0 +1,28 @@
+# PC_R0004
+
+**Level:** error (thrown, development only) · **Area:** runtime
+
+## What happened
+
+`entry.refresh()` or `entry.fetch()` was called on a query entry that has no options attached. An entry must be initialized (via `useQuery()` or `queryCache.ensure()`) before it can be refreshed or fetched.
+
+## How to fix it
+
+This is almost always an internal bug rather than something in your application code. If you are manually working with the query cache, make sure the entry was ensured before calling `refresh()`/`fetch()`.
+
+If you can reproduce it, please open an issue with a boiled-down example:
+
+- <https://github.com/posva/pinia-colada/issues>
+
+## Common causes
+
+- Calling `refresh()`/`fetch()` on an entry retrieved before it was ensured.
+- An internal edge case — reports are welcome.
+
+## Example output
+
+```txt
+[PC_R0004] "entry.refresh()" was called but the entry has no options.
+├▶ fix: This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0004
+```

--- a/docs/errors/pc_r0005.md
+++ b/docs/errors/pc_r0005.md
@@ -1,0 +1,39 @@
+# PC_R0005
+
+**Level:** warning (development only) · **Area:** runtime
+
+## What happened
+
+A composable created with `defineMutation()` was called **outside of a component or effect scope**. Without a scope, the mutation's reactive effects are never cleaned up, which can lead to memory leaks.
+
+## How to fix it
+
+Call the defined mutation from a place that has an effect scope:
+
+- inside a component `setup()`
+- inside an `effectScope()`
+- inside a Pinia store setup
+
+```ts
+import { defineMutation, useMutation } from '@pinia/colada'
+
+const useCreateTodo = defineMutation(() => useMutation({ mutation: createTodo }))
+
+// ✅ called inside setup()
+function MyComponent() {
+  const { mutate } = useCreateTodo()
+}
+```
+
+## Common causes
+
+- Calling the defined mutation at module top-level.
+- Calling it inside an async callback after `await`, which loses the active scope.
+
+## Example output
+
+```txt
+[PC_R0005] defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks.
+├▶ fix: Make sure to call it inside a component setup, an effect scope, or a store.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0005
+```

--- a/docs/errors/pc_r0006.md
+++ b/docs/errors/pc_r0006.md
@@ -1,0 +1,41 @@
+# PC_R0006
+
+**Level:** warning (development only) · **Area:** runtime
+
+## What happened
+
+`useMutationCache()` was called outside of an injection context (a component `setup`, a store, or a navigation guard). Vue's `inject` only works during these contexts, so it will additionally emit its own warning about `inject` being used incorrectly.
+
+## How to fix it
+
+Call `useMutationCache()` only where injection is allowed:
+
+- inside a component `setup()`
+- inside a Pinia store setup
+- inside a Vue Router navigation guard
+- inside a composable that is itself called from one of the above
+
+```ts
+import { useMutationCache } from '@pinia/colada'
+
+function useThing() {
+  // ✅ called from a composable used in setup()
+  const mutationCache = useMutationCache()
+  // ...
+}
+```
+
+If you genuinely need the cache outside of a component, pass the `pinia` instance explicitly: `useMutationCache(pinia)`.
+
+## Common causes
+
+- Calling `useMutationCache()` at module top-level.
+- Calling it inside an async callback after `await`, which loses the injection context.
+
+## Example output
+
+```txt
+[PC_R0006] useMutationCache() was called outside of an injection context (component setup, store, navigation guard). You will get a warning about "inject" being used incorrectly from Vue.
+├▶ fix: Make sure to use it only in allowed places. See https://vuejs.org/guide/reusability/composables.html#usage-restrictions
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0006
+```

--- a/docs/errors/pc_r0007.md
+++ b/docs/errors/pc_r0007.md
@@ -1,0 +1,33 @@
+# PC_R0007
+
+**Level:** error (development only) · **Area:** runtime
+
+## What happened
+
+The mutation cache `ref` was **reassigned** instead of being mutated in place. The cache must keep the same underlying object so Pinia Colada and its plugins can track entries. Reassigning it would break in production.
+
+## How to fix it
+
+Mutate the existing cache through its actions rather than swapping out the internal map.
+
+```ts
+const mutationCache = useMutationCache()
+
+// ❌ replaces the reactive value
+// mutationCache.caches.value = new Map()
+
+// ✅ use the public actions instead
+```
+
+## Common causes
+
+- Resetting the cache with an assignment instead of the provided actions.
+- A devtools or test helper assigning to the internal ref.
+
+## Example output
+
+```txt
+[PC_R0007] The mutation cache instance cannot be set directly, it must be modified.
+├▶ fix: Mutate the existing cache instead of reassigning it. This will fail in production.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0007
+```

--- a/docs/errors/pc_r0008.md
+++ b/docs/errors/pc_r0008.md
@@ -1,0 +1,35 @@
+# PC_R0008
+
+**Level:** error (development only) · **Area:** runtime
+
+## What happened
+
+A mutation entry was passed to `mutationCache.mutate()` **before being ensured**. An entry must be ensured first so it has its variables and options set up.
+
+## How to fix it
+
+If you are manually driving the mutation cache, always ensure the entry before mutating it:
+
+```ts
+const mutationCache = useMutationCache()
+
+// ✅ ensure first, then mutate
+mutationCache.mutate(mutationCache.ensure(entry, vars))
+```
+
+If you are not calling `mutationCache.mutate()` directly, this is likely an internal bug — please open an issue with a boiled-down reproduction:
+
+- <https://github.com/posva/pinia-colada/issues>
+
+## Common causes
+
+- Calling `mutationCache.mutate(entry)` without `ensure()`.
+- Reusing an entry object that was never ensured.
+
+## Example output
+
+```txt
+[PC_R0008] A mutation entry without a key was mutated before being ensured. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first.
+├▶ fix: Ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0008
+```

--- a/docs/errors/pc_r0009.md
+++ b/docs/errors/pc_r0009.md
@@ -1,0 +1,35 @@
+# PC_R0009
+
+**Level:** error (development only) · **Area:** runtime
+
+## What happened
+
+A mutation entry was **reused**: `mutationCache.mutate()` was called on an entry that already has an ongoing or completed request. Each mutation call needs a freshly ensured entry.
+
+## How to fix it
+
+If you are manually driving the mutation cache, ensure the entry before each mutation:
+
+```ts
+const mutationCache = useMutationCache()
+
+// ✅ ensure first, then mutate
+mutationCache.mutate(mutationCache.ensure(entry, vars))
+```
+
+If you are not calling `mutationCache.mutate()` directly, this is likely an internal bug — please open an issue with a boiled-down reproduction:
+
+- <https://github.com/posva/pinia-colada/issues>
+
+## Common causes
+
+- Calling `mutate()` twice on the same entry without re-ensuring it.
+- Holding onto a previously used entry instead of creating a new one.
+
+## Example output
+
+```txt
+[PC_R0009] A mutation entry without a key was reused. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first.
+├▶ fix: Ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0009
+```

--- a/docs/errors/pc_r0010.md
+++ b/docs/errors/pc_r0010.md
@@ -1,0 +1,38 @@
+# PC_R0010
+
+**Level:** error (thrown, development only) · **Area:** runtime
+
+## What happened
+
+`useInfiniteQuery()` tried to load the **previous** page, but `getPreviousPageParam` is not defined in its options. Without it, Pinia Colada cannot compute the parameter for the previous page.
+
+## How to fix it
+
+Define `getPreviousPageParam` in the options passed to `useInfiniteQuery()` whenever you call `loadPreviousPage()`:
+
+```ts
+import { useInfiniteQuery } from '@pinia/colada'
+
+useInfiniteQuery({
+  key: ['projects'],
+  query: ({ pageParam }) => fetchProjects(pageParam),
+  initialPageParam: 0,
+  getNextPageParam: (lastPage) => lastPage.nextCursor,
+  // ✅ required to load previous pages
+  getPreviousPageParam: (firstPage) => firstPage.prevCursor,
+})
+```
+
+If you only ever paginate forward, do not call `loadPreviousPage()`.
+
+## Common causes
+
+- Calling `loadPreviousPage()` on a query that only defines `getNextPageParam`.
+
+## Example output
+
+```txt
+[PC_R0010] useInfiniteQuery() is trying to load the previous page but `getPreviousPageParam` is not defined in options.
+├▶ fix: Define `getPreviousPageParam` in the options passed to useInfiniteQuery(). This will fail in production.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0010
+```

--- a/docs/errors/pc_r0011.md
+++ b/docs/errors/pc_r0011.md
@@ -1,0 +1,36 @@
+# PC_R0011
+
+**Level:** warning (development only) · **Area:** runtime
+
+## What happened
+
+`useInfiniteQuery()` tried to load a page (next or previous) but the query entry was **not found in the cache**. This usually means the query has not been mounted yet, or its key changed.
+
+## How to fix it
+
+Make sure the infinite query is mounted with `useInfiniteQuery()` before calling `loadNextPage()` / `loadPreviousPage()`, and that the key has not changed out from under it:
+
+```ts
+const { loadNextPage } = useInfiniteQuery({
+  key: ['projects'],
+  query: ({ pageParam }) => fetchProjects(pageParam),
+  initialPageParam: 0,
+  getNextPageParam: (lastPage) => lastPage.nextCursor,
+})
+
+// ✅ call after the query is mounted
+loadNextPage()
+```
+
+## Common causes
+
+- Calling `loadNextPage()`/`loadPreviousPage()` before the component using the query has rendered.
+- The query `key` changed, evicting the old entry from the cache.
+
+## Example output
+
+```txt
+[PC_R0011] useInfiniteQuery() cannot load the page: query entry not found in cache.
+├▶ fix: Make sure the query has been mounted with useInfiniteQuery() before calling loadNextPage()/loadPreviousPage().
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0011
+```

--- a/docs/errors/pc_r0012.md
+++ b/docs/errors/pc_r0012.md
@@ -1,0 +1,42 @@
+# PC_R0012
+
+**Level:** error (thrown, development only) · **Area:** runtime
+
+## What happened
+
+The `PiniaColada` plugin was installed but no Pinia instance was detected. Pinia Colada is built on top of Pinia and needs it to be installed first.
+
+## How to fix it
+
+Install Pinia **before** `PiniaColada`:
+
+```ts
+import { createApp } from 'vue'
+import { createPinia } from 'pinia'
+import { PiniaColada } from '@pinia/colada'
+
+const app = createApp(App)
+
+// ✅ pinia first
+app.use(createPinia())
+app.use(PiniaColada)
+```
+
+If you manage Pinia yourself, pass the instance explicitly:
+
+```ts
+app.use(PiniaColada, { pinia })
+```
+
+## Common causes
+
+- Registering `PiniaColada` before `createPinia()`.
+- Forgetting to call `app.use(createPinia())` entirely.
+
+## Example output
+
+```txt
+[PC_R0012] root pinia plugin not detected.
+├▶ fix: Make sure you install pinia before installing the "PiniaColada" plugin, or manually pass the pinia instance.
+╰▶ see: https://pinia-colada.esm.dev/errors/pc_r0012
+```

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "vitest": "^4.1.5",
     "vue": "^3.5.33"
   },
+  "dependencies": {
+    "nostics": "^0.4.0"
+  },
   "peerDependencies": {
     "pinia": "^2.2.6 || ^3.0.0",
     "vue": "^3.5.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      nostics:
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@ast-grep/cli':
         specifier: ^0.42.1
@@ -1780,8 +1784,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.117.0':
     resolution: {integrity: sha512-EPTs2EBijGmyhPso4rXAL0NSpECXER9IaVKFZEv83YcA6h4uhKW47kmYt+OZcSp130zhHx+lTWILDQ/LDkCRNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1792,8 +1808,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.117.0':
     resolution: {integrity: sha512-W7S99zFwVZhSbCxvjfZkioStFU249DBc4TJw/kK6kfKwx2Zew+jvizX5Y3ZPkAh7fBVUSNOdSeOqLBHLiP50tw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1804,8 +1832,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
     resolution: {integrity: sha512-9Hdm1imzrn4RdMYnQKKcy+7p7QsSPIrgVIZmpGSJT02nYDuBWLdG1pdYMPFoEo46yiXry3tS3RoHIpNbT1IiyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1816,8 +1856,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
     resolution: {integrity: sha512-jBxD7DtlHQ36ivjjZdH0noQJgWNouenzpLmXNKnYaCsBfo3jY95m5iyjYQEiWkvkhJ3TJUAs7tQ1/kEpY7x/Kg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1830,8 +1883,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-RPddpcE/0xxWaommWy0c5i/JdrXcXAkxBS2GOrAUh5LKmyCh03hpJedOAWszG4ADsKQwoUQQ1/tZVGRhZIWtKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1844,8 +1911,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-ujGcAx8xAMvhy7X5sBFi3GXML1EtyORuJZ5z2T6UV3U416WgDX/4OCi3GnoteeenvxIf6JgP45B+YTHpt71vpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1858,8 +1939,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-1QrTrf8rige7UPJrYuDKJLQOuJlgkt+nRSJLBMHWNm9TdivzP48HaK3f4q18EjNlglKtn03lgjMu4fryDm8X4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1872,8 +1967,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-QPJvFbnnDZZY7xc+xpbIBWLThcGBakwaYA9vKV8b3+oS5MGfAZUoTFJcix5+Zg2Ri46sOfrUim6Y6jsKNcssAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
+    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1883,8 +1991,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
     resolution: {integrity: sha512-GpxeGS+Vo030DsrXeRPc7OSJOQIyAHkM3mzwBcnQjg/79XnOIDDMXJ5X6/aNdkVt/+Pv35pqKzGA4TQau97x8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1895,8 +2014,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
     resolution: {integrity: sha512-ysRJAjIbB4e5y+t9PZs7TwbgOV/GVT//s30AORLCT/pedYwpYzHq6ApXK7is9fvyfZtgT3anNir8+esurmyaDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1909,6 +2040,9 @@ packages:
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
     resolution: {integrity: sha512-17giX7h5VR9Eodru4OoSCFdgwLFIaUxeEn8JWe0vMZrAuRbT9NiDTy5dXdbGQBoO8aXPkbGS38FGlvbi31aujw==}
@@ -5837,6 +5971,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nostics@0.4.0:
+    resolution: {integrity: sha512-HjGay1njIki+R6zAUnKfxDVRrDcvy0ELPCj+5b/KbolnGKjOGxBNEd28Hn5ziiIuodFv034nLYUW/szFOiy2Iw==}
+
   npm-normalize-package-bin@6.0.0:
     resolution: {integrity: sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -5958,6 +6095,10 @@ packages:
 
   oxc-parser@0.117.0:
     resolution: {integrity: sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-parser@0.132.0:
+    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-transform@0.117.0:
@@ -9209,49 +9350,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -9262,13 +9451,29 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
     optional: true
 
   '@oxc-project/types@0.117.0': {}
@@ -9276,6 +9481,8 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.129.0': {}
+
+  '@oxc-project/types@0.132.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
     optional: true
@@ -13177,6 +13384,12 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nostics@0.4.0:
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.132.0
+      unplugin: 3.0.0
+
   npm-normalize-package-bin@6.0.0: {}
 
   npm-run-all2@9.0.1:
@@ -13478,6 +13691,31 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  oxc-parser@0.132.0:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.132.0
+      '@oxc-parser/binding-android-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-x64': 0.132.0
+      '@oxc-parser/binding-freebsd-x64': 0.132.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-musl': 0.132.0
+      '@oxc-parser/binding-openharmony-arm64': 0.132.0
+      '@oxc-parser/binding-wasm32-wasi': 0.132.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
 
   oxc-transform@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:

--- a/src/define-mutation.ts
+++ b/src/define-mutation.ts
@@ -5,6 +5,7 @@ import { useMutation } from './use-mutation'
 import type { UseMutationReturn } from './use-mutation'
 import type { UseMutationOptions } from './mutation-options'
 import type { _EmptyObject } from './utils'
+import { diagnostics } from './diagnostics'
 
 /**
  * Define a mutation with the given options. Similar to `useMutation(options)` but allows you to reuse the mutation in
@@ -74,9 +75,7 @@ export function defineMutation(
         }
       })
     } else if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        `[@pinia/colada]: defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks. Make sure to call it inside a component setup, an effect scope, or a store.`,
-      )
+      diagnostics.PC_R0005()
     }
 
     return ret

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,83 @@
+import { createConsoleReporter, defineDiagnostics } from 'nostics'
+
+/**
+ * Diagnostics catalog for Pinia Colada. Each code maps to a stable error page
+ * under https://pinia-colada.esm.dev/errors/<code>.
+ *
+ * Codes follow `PC_XNNNN` where the category letter is the **area**:
+ *
+ * - `R` runtime
+ * - `C` config
+ * - `D` deprecation
+ *
+ * Published codes are permanent: never rename or reuse one.
+ */
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: (code) => `https://pinia-colada.esm.dev/errors/${code.toLowerCase()}`,
+  reporters: [/*#__PURE__*/ createConsoleReporter()],
+  codes: {
+    // useQueryCache() called outside of an injection context
+    PC_R0001: {
+      why: 'useQueryCache() was called outside of an injection context (component setup, store, navigation guard). You will get a warning about "inject" being used incorrectly from Vue.',
+      fix: 'Make sure to use it only in allowed places. See https://vuejs.org/guide/reusability/composables.html#usage-restrictions',
+    },
+    // The reactive query cache was replaced instead of mutated
+    PC_R0002: {
+      why: 'The query cache cannot be directly set, it must be modified only.',
+      fix: 'Mutate the existing cache instead of reassigning it. This will fail in production.',
+    },
+    // useQuery() called with an empty array key
+    PC_R0003: {
+      why: 'useQuery() was called with an empty array as the key. It must have at least one element.',
+      fix: 'Provide a key with at least one element, e.g. ["todos"].',
+    },
+    // entry.refresh()/entry.fetch() called on an entry with no options
+    PC_R0004: {
+      why: (p: { action: 'refresh' | 'fetch' }) =>
+        `"entry.${p.action}()" was called but the entry has no options.`,
+      fix: 'This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!',
+    },
+    // defineMutation() composable called outside of a component or effect scope
+    PC_R0005: {
+      why: 'defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks.',
+      fix: 'Make sure to call it inside a component setup, an effect scope, or a store.',
+    },
+    // useMutationCache() called outside of an injection context
+    PC_R0006: {
+      why: 'useMutationCache() was called outside of an injection context (component setup, store, navigation guard). You will get a warning about "inject" being used incorrectly from Vue.',
+      fix: 'Make sure to use it only in allowed places. See https://vuejs.org/guide/reusability/composables.html#usage-restrictions',
+    },
+    // The reactive mutation cache was replaced instead of mutated
+    PC_R0007: {
+      why: 'The mutation cache instance cannot be set directly, it must be modified.',
+      fix: 'Mutate the existing cache instead of reassigning it. This will fail in production.',
+    },
+    // A mutation entry was mutated before being ensured
+    PC_R0008: {
+      why: (p: { keyMessage: string }) =>
+        `A mutation entry ${p.keyMessage} was mutated before being ensured. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first.`,
+      fix: 'Ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.',
+    },
+    // A mutation entry was reused
+    PC_R0009: {
+      why: (p: { keyMessage: string }) =>
+        `A mutation entry ${p.keyMessage} was reused. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first.`,
+      fix: 'Ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.',
+    },
+    // loadPreviousPage() called without getPreviousPageParam defined
+    PC_R0010: {
+      why: 'useInfiniteQuery() is trying to load the previous page but `getPreviousPageParam` is not defined in options.',
+      fix: 'Define `getPreviousPageParam` in the options passed to useInfiniteQuery(). This will fail in production.',
+    },
+    // loadPage() could not find the query entry in the cache
+    PC_R0011: {
+      why: 'useInfiniteQuery() cannot load the page: query entry not found in cache.',
+      fix: 'Make sure the query has been mounted with useInfiniteQuery() before calling loadNextPage()/loadPreviousPage().',
+    },
+    // PiniaColada plugin installed without pinia
+    PC_R0012: {
+      why: 'root pinia plugin not detected.',
+      fix: 'Make sure you install pinia before installing the "PiniaColada" plugin, or manually pass the pinia instance.',
+    },
+  },
+})

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -7,6 +7,7 @@ import { useQueryCache, type QueryCache, type UseQueryEntry } from './query-stor
 import { noop, toValueWithArgs } from './utils'
 import type { _RemoveMaybeRef } from './utils'
 import type { EntryKey, EntryKeyTagged } from './entry-keys'
+import { diagnostics } from './diagnostics'
 
 /**
  * Structure of data stored for infinite queries.
@@ -425,10 +426,7 @@ export function useInfiniteQuery<
 
             if (process.env.NODE_ENV !== 'production') {
               if (position === 0 && !opts.getPreviousPageParam) {
-                const msg =
-                  '[useInfiniteQuery] Trying to load previous page but `getPreviousPageParam` is not defined in options. This will fail in production.'
-                console.warn(msg)
-                throw new Error(msg)
+                throw diagnostics.PC_R0010()
               }
             }
 
@@ -528,7 +526,7 @@ export function useInfiniteQuery<
     const entry = queryCache.get(toValue(opts.key))
     if (!entry) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('[useInfiniteQuery] Cannot load next page: query entry not found in cache.')
+        diagnostics.PC_R0011()
       }
       return null
     }

--- a/src/mutation-store.ts
+++ b/src/mutation-store.ts
@@ -12,9 +12,10 @@ import type { App, EffectScope, ShallowRef } from 'vue'
 import { find } from './entry-keys'
 import type { EntryFilter } from './entry-filter'
 import type { _EmptyObject } from './utils'
-import { noop, toValueWithArgs, warnOnce } from './utils'
+import { noop, toValueWithArgs } from './utils'
 import type { _ReduceContext } from './use-mutation'
 import { useMutationOptions } from './mutation-options'
+import { diagnostics } from './diagnostics'
 import type {
   UseMutationContextCommon,
   UseMutationOptions,
@@ -22,6 +23,9 @@ import type {
 } from './mutation-options'
 import type { EntryKey } from './entry-keys'
 import type { MutationMeta } from './types-extension'
+
+// dev-only guard so the missing injection context diagnostic is reported once (matches the previous `warnOnce` behavior)
+let warnedNoInjectionContext = false
 
 /**
  * Allows defining extensions to the mutation entry that are returned by `useMutation()`.
@@ -137,9 +141,7 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
           set:
             process.env.NODE_ENV !== 'production'
               ? () => {
-                  console.error(
-                    `[@pinia/colada]: The mutation cache instance cannot be set directly, it must be modified. This will fail in production.`,
-                  )
+                  diagnostics.PC_R0007({}, { method: 'error' })
                 }
               : noop,
         },
@@ -150,11 +152,9 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
   const scope = getCurrentScope()!
 
   if (process.env.NODE_ENV !== 'production') {
-    if (!hasInjectionContext()) {
-      warnOnce(
-        `useMutationCache() was called outside of an injection context (component setup, store, navigation guard) You will get a warning about "inject" being used incorrectly from Vue. Make sure to use it only in allowed places.\n` +
-          `See https://vuejs.org/guide/reusability/composables.html#usage-restrictions`,
-      )
+    if (!hasInjectionContext() && !warnedNoInjectionContext) {
+      warnedNoInjectionContext = true
+      diagnostics.PC_R0006()
     }
   }
 
@@ -398,18 +398,14 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
       const key = entry.key?.join('/')
       const keyMessage = key ? `with key "${key}"` : 'without a key'
       if (entry.id === 0) {
-        console.error(
-          `[@pinia/colada] A mutation entry ${keyMessage} was mutated before being ensured. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
-        )
+        diagnostics.PC_R0008({ keyMessage }, { method: 'error' })
       }
       if (
         // the entry has already an ongoing request
         entry.state.value.status !== 'pending' ||
         entry.asyncStatus.value === 'loading'
       ) {
-        console.error(
-          `[@pinia/colada] A mutation entry ${keyMessage} was reused. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
-        )
+        diagnostics.PC_R0009({ keyMessage }, { method: 'error' })
       }
     }
 

--- a/src/pinia-colada.ts
+++ b/src/pinia-colada.ts
@@ -6,6 +6,7 @@ import { useQueryCache } from './query-store'
 import type { PiniaColadaPlugin } from './plugins'
 import { USE_MUTATION_DEFAULTS, USE_MUTATION_OPTIONS_KEY } from './mutation-options'
 import type { UseMutationOptionsGlobal } from './mutation-options'
+import { diagnostics } from './diagnostics'
 
 /**
  * Options for the Pinia Colada plugin.
@@ -62,9 +63,7 @@ export const PiniaColada: Plugin<[options?: PiniaColadaOptions]> = (
   })
 
   if (process.env.NODE_ENV !== 'production' && !pinia) {
-    throw new Error(
-      '[@pinia/colada] root pinia plugin not detected. Make sure you install pinia before installing the "PiniaColada" plugin or to manually pass the pinia instance.',
-    )
+    throw diagnostics.PC_R0012()
   }
 
   // install plugins

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -18,7 +18,11 @@ import type { UseQueryOptions, UseQueryOptionsWithDefaults } from './query-optio
 import type { EntryFilter } from './entry-filter'
 import { find, START_EXT, toCacheKey } from './entry-keys'
 import type { ErrorDefault, QueryMeta } from './types-extension'
-import { toValueWithArgs, warnOnce } from './utils'
+import { toValueWithArgs } from './utils'
+import { diagnostics } from './diagnostics'
+
+// dev-only guard so the missing injection context diagnostic is reported once (matches the previous `warnOnce` behavior)
+let warnedNoInjectionContext = false
 
 /**
  * Allows defining extensions to the query entry that are returned by `useQuery()`.
@@ -247,9 +251,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       () => caches.value !== cachesRaw,
       (isDifferent) => {
         if (isDifferent) {
-          console.error(
-            `[@pinia/colada] The query cache cannot be directly set, it must be modified only. This will fail on production`,
-          )
+          diagnostics.PC_R0002({}, { method: 'error' })
         }
       },
     )
@@ -264,11 +266,9 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
     getActivePinia()!._a
 
   if (process.env.NODE_ENV !== 'production') {
-    if (!hasInjectionContext()) {
-      warnOnce(
-        `useQueryCache() was called outside of an injection context (component setup, store, navigation guard) You will get a warning about "inject" being used incorrectly from Vue. Make sure to use it only in allowed places.\n` +
-          `See https://vuejs.org/guide/reusability/composables.html#usage-restrictions`,
-      )
+    if (!hasInjectionContext() && !warnedNoInjectionContext) {
+      warnedNoInjectionContext = true
+      diagnostics.PC_R0001()
     }
   }
 
@@ -517,9 +517,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       const keyHash = toCacheKey(key)
 
       if (process.env.NODE_ENV !== 'production' && keyHash === '[]') {
-        throw new Error(
-          `useQuery() was called with an empty array as the key. It must have at least one element.`,
-        )
+        throw diagnostics.PC_R0003()
       }
 
       // do not reinitialize the entry
@@ -648,9 +646,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       options = entry.options,
     ): Promise<DataState<TData, TError, TDataInitial>> => {
       if (process.env.NODE_ENV !== 'production' && !options) {
-        throw new Error(
-          `"entry.refresh()" was called but the entry has no options. This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!`,
-        )
+        throw diagnostics.PC_R0004({ action: 'refresh' })
       }
 
       if (entry.state.value.error || entry.stale) {
@@ -673,9 +669,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       options = entry.options,
     ): Promise<DataState<TData, TError, TDataInitial>> => {
       if (process.env.NODE_ENV !== 'production' && !options) {
-        throw new Error(
-          `"entry.fetch()" was called but the entry has no options. This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!`,
-        )
+        throw diagnostics.PC_R0004({ action: 'fetch' })
       }
 
       entry.asyncStatus.value = 'loading'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -185,23 +185,6 @@ export const setReactiveValue = Object.assign as <T>(value: T, ...args: T[]) => 
 export interface _EmptyObject {}
 
 /**
- * Dev only warning that is only shown once.
- */
-const warnedMessages = new Set<string>()
-
-/**
- * Warns only once. This should only be used in dev
- *
- * @param message - Message to show
- * @param id - Unique id for the message, defaults to the message
- */
-export function warnOnce(message: string, id: string = message) {
-  if (warnedMessages.has(id)) return
-  warnedMessages.add(id)
-  console.warn(`[@pinia/colada]: ${message}`)
-}
-
-/**
  * @internal
  */
 export type _IsMaybeRefOrGetter<T> = [T] extends [MaybeRefOrGetter<infer U>]


### PR DESCRIPTION
Nostics migration experiment — **Claude Opus** run.

## Shape
- 12 codes (`PC_R0001`–`PC_R0012`), merged `entry.refresh()`/`entry.fetch()` via an `action` param
- 13 docs pages under `docs/errors/` + sidebar entry; best index page (code structure, dev/prod stripping explained)
- `warnOnce` → module-level booleans, helper removed

## Review notes
- Config error (pinia not detected) filed as `PC_R0012` (runtime) instead of a `C` code
- A few `fix` texts contain "This will fail in production" (consequence, not an action)
- Passes pre-formatted `keyMessage` strings as params instead of raw `key` values

Verified: full vitest suite + typecheck, lint, `docs:build` all pass.

Part of a 4-way model comparison of the `nostics-migration` skill (see sibling PRs).