### PR TITLE
feat: nostics migration — Codex GPT-5.5

### DIFF
--- a/.claude/skills/nostics-migration/SKILL.md
+++ b/.claude/skills/nostics-migration/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: nostics-migration
+description: Migrate a library's user-facing errors, warnings, and logs to nostics diagnostics. Use when replacing console.warn/console.error, warn() helpers, or thrown Errors with stable diagnostic codes, or when designing or extending a defineDiagnostics catalog.
+---
+
+# Migrate errors and warnings to nostics
+
+Turn ad hoc warnings and errors into a catalog of stable diagnostic codes **without changing runtime behavior**. API details: `references/nostics-api.md`.
+
+## What to migrate
+
+Inventory `console.warn`, `console.error`, `warn(...)` helpers, `throw new Error(...)`, `Promise.reject(new Error(...))`. Skip tests, fixtures, snapshots, and generated output. Plain debug `console.log`s are usually not user-facing; leave them.
+
+Migrate:
+
+- dev warnings that report and keep going
+- warnings followed by recovery or a fallback (replace only the report, keep the recovery)
+- plain user-facing thrown or rejected `Error`s (the diagnostic becomes the thrown/rejected value)
+- deprecation notices
+- build/config errors caused by a user's file: always pass **both** the original error as `cause` and the file as `sources`, because the JS stack points inside the library and is useless to the user
+
+Do **not** migrate:
+
+- **structured errors other code inspects** (type fields, private symbols, `isXxxError()` guards, `instanceof` checks): they are control flow, not reporting. Leave them unchanged. Only if such an error is also deliberately user-facing, add a separate dev-only report with the error as `cause`; never replace the error object itself.
+- **catch blocks that only log a native/platform error and fall back** when the library cannot name a likely cause or a concrete fix: the native error is the best available information, keep the plain log. This exception covers platform APIs failing (e.g. `history.pushState`, storage quota), **not** errors caused by the user's own files: a caught parse or config error on a user file should become a diagnostic carrying the original error as `cause` and the file as `sources`.
+- anything where the diagnostic would only restate "an operation failed". A diagnostic earns its place by naming a likely user-code problem or a concrete fix.
+
+## Preserve behavior exactly
+
+A project's dev guard may be `process.env.NODE_ENV !== 'production'` or its own build-time constant (libraries often define a flag for this; recognize whatever the codebase uses). Written as `DEV` below; treat all forms the same:
+
+- Keep existing dev guards exactly as they are. nostics stripping is additive and does not replace them. If a throw or reject only happened in dev, it must still only happen in dev.
+- Never add a guard the original did not have. A throw or report that fired in production keeps firing in production builds that do not use stripping; note that migrating an unguarded report-only call makes it strippable, so once `nosticsStrip` runs in the build it disappears from production bundles. That is usually the goal of the migration, but if the library deliberately reports in production, surface that decision instead of changing it silently.
+- Keep throw vs reject, timing, recovery code, and returned fallbacks.
+- Keep structured error shapes (fields, symbols). Migrating a throw replaces the thrown message with the diagnostic's `why`: if tests assert the exact old text, update them deliberately as part of the migration, never weaken the message to dodge a test.
+
+## Catalog shape
+
+One catalog file per area of the library (a single `src/diagnostics.ts` is fine for small ones), exported directly. No factory wrappers and no deep barrel re-exports: the strip plugin tracks the export across one relative import. `nostics` is a runtime import: add it to `dependencies`, not `devDependencies` (library bundlers refuse or inline it otherwise).
+
+```ts
+import { createConsoleReporter, defineDiagnostics } from 'nostics'
+
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: (code) => `https://example.com/e/${code.toLowerCase()}`,
+  reporters: [/*#__PURE__*/ createConsoleReporter()],
+  codes: {
+    LIB_R0001: {
+      why: (p: { hook: string }) => `${p.hook}() must be called at the top of a setup function.`,
+      fix: 'Move the call into setup() or a composable called by setup().',
+    },
+  },
+})
+```
+
+- Codes are `PREFIX_XNNNN`. Pick the category letter by **area**, not severity: `B` build, `R` runtime, `C` config, `D` deprecation. A runtime warning is `R`; reserve `D` for deprecations. Published codes are permanent: never rename or reuse one.
+- `why` says what happened with runtime values interpolated through typed param functions (both `why` and `fix` accept them; their params are merged and required at the call site). `fix` is the concrete next action, never a restatement of the problem.
+- Extra `console.warn`/`console.error` arguments must not be lost: an error value becomes `cause`; data values are interpolated into `why` (e.g. `JSON.stringify(p.value)`).
+- `cause` and `sources` (`'file:line:column'` strings pointing at user code) go **inside the params object** (the first argument), merged with the message params. The second argument is reporter options only, e.g. `{ method: 'error' }`.
+- `docsBase` is optional. If the project has no documented error-page URL scheme, propose one and surface it to the maintainer rather than inventing pages that do not exist.
+
+## Call-site patterns
+
+| Before                                      | After                                                                                                  |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `DEV && warn(msg)`                          | `DEV && diagnostics.LIB_R0001(params)` (same guard)                                                    |
+| warn, then recover/fallback                 | diagnostic, then the same recovery                                                                     |
+| warn, then `throw new Error(...)`           | `throw diagnostics.LIB_R0002(params)`                                                                  |
+| warn, then `Promise.reject(new Error(...))` | `return Promise.reject(diagnostics.LIB_R0003(params))`                                                 |
+| `console.error(...)` level                  | `diagnostics.LIB_B0001(params, { method: 'error' })`                                                   |
+| caught error tied to a user file            | `diagnostics.LIB_B0002({ ...params, cause: err, sources: ['src/file.ts:10:5'] }, { method: 'error' })` |
+| structured/internal error                   | leave unchanged                                                                                        |
+
+Calling a handle always runs the reporters, so `throw diagnostics.CODE(params)` reports **and** throws. For a warn-then-throw site that is the same double output it already had; for a bare `throw new Error(...)` it adds a console report before the throw, which is normally fine but worth mentioning if the library is strict about console output.
+
+Report-only calls must stay bare expression statements (`DEV && diagnostics.LIB_R0001(p)` included) so `nosticsStrip` can remove them in production. `throw`/`return`/assigned diagnostics are behavior and stay.
+
+Dropping diagnostics from production builds takes two pieces: `/*#__PURE__*/` annotations on the catalog (`defineDiagnostics(...)` and each reporter factory call inside it) so an unused catalog tree-shakes away, and a `DEV` guard on every report-only call site. Both can be written manually in source, or the `nosticsStrip` build plugin adds them at build time (`import { nosticsStrip } from 'nostics/unplugin/strip-transform'`, then the matching unplugin adapter: `nosticsStrip.rolldown()`, `.vite()`, `.rollup()`, ...). Decide from context: when every report-only site is already dev-guarded, manual annotations in the catalog file are enough and avoid a build transform; reach for the plugin when call sites are unguarded and stripping is wanted. Either way the behavior rule holds: if the library deliberately reports unguarded in production, do not silence it with a guard or the plugin; ask the maintainer.
+
+## Verify
+
+- Tests for warnings, throws, guards, and error shapes still pass; tests asserting exact message text are updated consciously, not accidentally.
+- Dev-only gates are still present everywhere the source had them, and no new gates were added.
+- Report-only diagnostics remain strippable expression statements. Thrown/returned diagnostics keep their message text in production by design: they are behavior, not reports.

--- a/.claude/skills/nostics-migration/references/nostics-api.md
+++ b/.claude/skills/nostics-migration/references/nostics-api.md
@@ -1,0 +1,121 @@
+# nostics API cheat sheet
+
+Accurate as of nostics 0.4 (https://www.npmjs.com/package/nostics).
+
+## Core
+
+```ts
+import { createConsoleReporter, defineDiagnostics, Diagnostic } from 'nostics'
+```
+
+`defineDiagnostics({ docsBase?, reporters?, codes })` returns one callable handle per code. Calling a handle creates a fresh `Diagnostic`, runs every reporter in order, and returns the instance. `throw` the return value to raise it — reporters still run first, so a thrown diagnostic also reports.
+
+`Diagnostic extends Error`:
+
+- `name`: the code (e.g. `LIB_R0001`)
+- `message` / `why`: resolved explanation
+- `fix?`: how to resolve it
+- `docs?`: docs URL
+- `sources?`: `'file:line:column'` strings from the call site
+- `cause?`: original error from the call site
+- `toJSON()`: `{ name, why, fix, docs, sources, cause, stack }` (all keys present; `JSON.stringify` drops the `undefined` ones later)
+
+## Definitions
+
+```ts
+export const diagnostics = defineDiagnostics({
+  docsBase: (code) => `https://example.com/e/${code.toLowerCase()}`,
+  reporters: [createConsoleReporter()],
+  codes: {
+    LIB_B2011: {
+      why: (p: { src: string; mode: 'client' | 'server' }) =>
+        `Plugin "${p.src}" conflicts with mode "${p.mode}".`,
+      fix: (p: { mode: 'client' | 'server' }) =>
+        `Rename the file or register it with mode "${p.mode === 'client' ? 'server' : 'client'}".`,
+      docs: 'https://example.com/custom', // optional per-code override, or `false` to omit
+    },
+  },
+})
+```
+
+- `why` is required (string or typed param function); it becomes `Error.message`.
+- `fix` is optional but recommended whenever the solution is known.
+- Params from `why` and `fix` are intersected and required (type-checked) at the call site.
+- `docsBase` as a string appends `/${code.toLowerCase()}`; as a function it receives the code and returns the full URL (or `undefined` to omit).
+
+## Call sites
+
+```ts
+diagnostics.LIB_B2011({ src, mode }) // report only — returns the Diagnostic
+throw diagnostics.LIB_B2011({ src, mode }) // raise
+
+// runtime fields merge into the same params object:
+diagnostics.LIB_B2011({
+  src,
+  mode,
+  cause: originalError,
+  sources: ['nuxt.config.ts:42:3'],
+})
+
+// reporter options are the second argument:
+diagnostics.LIB_B2011({ src, mode }, { method: 'error' })
+```
+
+`sources` matters most for build/config diagnostics where the JS stack points inside the library but the problem lives in a user file.
+
+## Reporters and formatters
+
+| Built-in                          | Import                    | Use                                                                                                                               |
+| --------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `createConsoleReporter(options?)` | `nostics`                 | `console[method](formatter(d))`; `method` defaults to `'warn'`, overridable per call via `{ method: 'log' \| 'warn' \| 'error' }` |
+| `createFileReporter(options?)`    | `nostics/reporters/node`  | NDJSON appended to `.nostics.log`                                                                                                 |
+| `createFetchReporter(url)`        | `nostics/reporters/fetch` | POSTs diagnostic JSON; failures swallowed                                                                                         |
+| `createDevReporter()`             | `nostics/reporters/dev`   | browser → Vite dev server via `import.meta.hot`                                                                                   |
+
+Formatters: `formatDiagnostic` (plain text, default), `ansiFormatter(colors)` from `nostics/formatters/ansi`, `jsonFormatter` from `nostics/formatters/json`.
+
+Custom reporter: `(diagnostic: Diagnostic, options?: Opts) => void`. Declaring a required `options` type makes the second call-site argument required and typed.
+
+Output shape of `formatDiagnostic`:
+
+```txt
+[LIB_B2011] Plugin `./analytics.server.ts` conflicts with mode `client`.
+├▶ fix: Rename the file or register it with the other mode.
+├▶ sources: modules/analytics.ts:18:5
+╰▶ see: https://example.com/e/lib_b2011
+```
+
+## Production stripping
+
+```ts
+import { nosticsStrip } from 'nostics/unplugin/strip-transform'
+// vite: nosticsStrip.vite()  — also .rollup() .rolldown() .webpack() .esbuild() ...
+```
+
+The plugin marks `defineDiagnostics()` as `/*#__PURE__*/` and wraps **bare diagnostic expression statements** with `process.env.NODE_ENV !== "production" &&` so bundlers drop them:
+
+```ts
+diagnostics.LIB_R0001() // strippable
+condition && diagnostics.LIB_R0002() // strippable
+```
+
+These stay, because they are behavior:
+
+```ts
+throw diagnostics.LIB_R0003()
+return diagnostics.LIB_R0004()
+const d = diagnostics.LIB_R0005()
+fn(diagnostics.LIB_R0006())
+```
+
+For the cross-file tracking to work: relative imports, export the `defineDiagnostics()` result directly, no factory wrappers, no deep barrels.
+
+Stripping is **additive**. It does not replace a library's own dev/prod compile-time guards (`process.env.NODE_ENV` checks or project-defined build-time constants); keep those guards unless the project deliberately changes its build strategy and verifies the bundle.
+
+The plugin is optional: writing `/*#__PURE__*/` manually before `defineDiagnostics(` and each reporter factory call, with every report-only call site dev-guarded in source, achieves the same production output without a build transform.
+
+Dev-time collection for apps: `nosticsCollector.vite()` from `nostics/unplugin/dev-server-collector` + `createDevReporter()` in the catalog reporters.
+
+## Docs registry
+
+Each published code should keep a stable URL forever. Page template: title with code, level, what happened, how to fix it, common causes, example output. A CI check can diff catalog keys against docs pages.

--- a/devtools/package.json
+++ b/devtools/package.json
@@ -54,6 +54,9 @@
     "build:panel": "vite build --config vite.config.panel.ts",
     "build": "pnpm run --stream '/^build:/'"
   },
+  "dependencies": {
+    "nostics": "^0.4.0"
+  },
   "devDependencies": {
     "@iconify-json/lucide": "^1.2.104",
     "@pinia/colada": "workspace:^*",

--- a/devtools/src/PiniaColadaDevtools.vue
+++ b/devtools/src/PiniaColadaDevtools.vue
@@ -6,6 +6,7 @@ import type { AppEmits, DevtoolsEmits } from '@pinia/colada-devtools/shared'
 import { createQueryEntryPayload, createMutationEntryPayload } from './pc-devtools-info-plugin'
 // use dependency free simple useEventListener because this component is used directly in the app
 import { useEventListener } from './use-event-listener'
+import { diagnostics } from './diagnostics'
 
 const emit = defineEmits<{
   close: []
@@ -260,14 +261,12 @@ transmitter.on('mutations:replay', (id) => {
   const entry = mutationCache.get(id)
 
   if (!entry) {
-    console.warn('[@pinia/colada] Cannot replay: mutation entry not found')
+    diagnostics.PCD_R0001()
     return
   }
 
   if (entry.gcTimeout) {
-    console.warn(
-      "[@pinia/colada] Cannot replay: mutation is in the process of being garbage collected. It isn't used anywhere and replaying it will have no effect.",
-    )
+    diagnostics.PCD_R0002()
     return
   }
 
@@ -310,13 +309,13 @@ function closePiPWindow() {
 function openPiPWindow() {
   const devtools = devtoolsEl.value
   if (!devtools || !devtools.shadowRoot) {
-    throw new Error('No devtools elemnt found for Pinia Colada devtools')
+    throw diagnostics.PCD_R0003({ target: 'devtools element' })
   }
 
   const devtoolsRootEl = devtools.shadowRoot.getElementById('root')
 
   if (!devtoolsRootEl) {
-    throw new Error('No devtools root element found for Pinia Colada devtools')
+    throw diagnostics.PCD_R0003({ target: 'devtools root element' })
   }
 
   const windowWidth = Math.max(devtoolsRootEl.offsetWidth, 400)
@@ -330,7 +329,7 @@ function openPiPWindow() {
   )
 
   if (!pip) {
-    throw new Error('Failed to open PiP window for Pinia Colada devtools')
+    throw diagnostics.PCD_R0004()
   }
 
   pipWindow.value = pip
@@ -361,7 +360,7 @@ function openPiPWindow() {
 
 function attachCssPropertyRules(el: HTMLElement, doc: Document = document) {
   if (!el || !el.shadowRoot) {
-    throw new Error('No devtools element found for Pinia Colada devtools')
+    throw diagnostics.PCD_R0003({ target: 'devtools element' })
   }
 
   const style = doc.getElementById('__pc-tw-properties') ?? doc.createElement('style')
@@ -388,7 +387,7 @@ let tries = 0
 async function devtoolsOnReady() {
   if (!devtoolsEl.value) {
     if (++tries > 100) {
-      throw new Error('Failed to find devtools element for Pinia Colada devtools')
+      throw diagnostics.PCD_R0005()
     }
     setTimeout(() => {
       devtoolsOnReady()

--- a/devtools/src/diagnostics.ts
+++ b/devtools/src/diagnostics.ts
@@ -1,0 +1,83 @@
+import { createConsoleReporter, defineDiagnostics } from 'nostics'
+
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: (code) => `https://pinia-colada.esm.dev/diagnostics/${code.toLowerCase()}`,
+  reporters: [/*#__PURE__*/ createConsoleReporter()],
+  codes: {
+    PCD_R0001: {
+      why: '[@pinia/colada] Cannot replay: mutation entry not found',
+      fix: 'Select a mutation that is still present in the devtools mutation list before replaying it.',
+    },
+    PCD_R0002: {
+      why: "[@pinia/colada] Cannot replay: mutation is in the process of being garbage collected. It isn't used anywhere and replaying it will have no effect.",
+      fix: 'Replay an active mutation entry, or trigger the mutation again from the application.',
+    },
+    PCD_R0003: {
+      why: (p: { target: 'devtools element' | 'devtools root element' }) =>
+        `No ${p.target} found for Pinia Colada devtools`,
+      fix: 'Make sure the Pinia Colada devtools custom element is mounted before opening the panel window.',
+    },
+    PCD_R0004: {
+      why: 'Failed to open PiP window for Pinia Colada devtools',
+      fix: 'Allow popups for the current page, then try opening the Pinia Colada devtools window again.',
+    },
+    PCD_R0005: {
+      why: 'Failed to find devtools element for Pinia Colada devtools',
+      fix: 'Reload the page and make sure the Pinia Colada devtools wrapper is mounted.',
+    },
+    PCD_R0006: {
+      why: (p: { resource: 'duplex channel' | 'query entries' | 'mutation entries' }) =>
+        `The ${p.resource} is not provided. Make sure to use it inside the context of a component that provides it.`,
+      fix: 'Render this composable under the devtools provider component that provides the required injection key.',
+    },
+    PCD_R0007: {
+      why: (p: { channel: string; data: string }) => `${p.channel}: invalid message ${p.data}`,
+      fix: 'Send RPC messages as objects with a string id and serialized data payload.',
+    },
+    PCD_R0008: {
+      why: (p: { channel: string }) => `${p.channel}: message error`,
+      fix: 'Check that all RPC payload values can be cloned through MessagePort.',
+    },
+    PCD_R0009: {
+      why: 'Cannot set value with empty path',
+      fix: 'Select a nested value in the JSON editor before applying an update.',
+    },
+    PCD_R0010: {
+      why: (p: { path: string; index: number; value: string }) =>
+        `Invalid path: ${p.path} at index ${p.index}. Current value: ${p.value}`,
+      fix: 'Edit an existing object or array path, or refresh the query entry before editing.',
+    },
+    PCD_R0011: {
+      why: (p: { path: string }) => `Invalid final parent in path: ${p.path}`,
+      fix: 'Edit a path whose parent is still an object or array.',
+    },
+    PCD_R0012: {
+      why: (p: { path: string }) => `Failed to update value at path: ${p.path}`,
+      fix: 'Refresh the selected query entry and retry the edit.',
+    },
+    PCD_R0013: {
+      why: 'Invalid JSON',
+      fix: 'Enter valid JSON, or use the explicit undefined value when editing an undefined value.',
+    },
+    PCD_R0014: {
+      why: 'Invalid BigInt',
+      fix: 'Enter a valid BigInt string without decimal points or separators.',
+    },
+    PCD_R0015: {
+      why: 'Invalid number',
+      fix: 'Enter a value that JavaScript can parse as a finite number.',
+    },
+    PCD_R0016: {
+      why: "root node of element isn't a ShadowRoot or Document",
+      fix: 'Pass an element attached to a document or shadow root.',
+    },
+  },
+})
+
+export function formatDiagnosticValue(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/devtools/src/panel/components/editable-json/JsonItem.vue
+++ b/devtools/src/panel/components/editable-json/JsonItem.vue
@@ -9,6 +9,7 @@ import {
   isNonSerializableValue,
 } from '@pinia/colada-devtools/shared'
 import UButton from '../UButton.ce.vue'
+import { diagnostics } from '../../../diagnostics'
 import ILucideChevronRight from '~icons/lucide/chevron-right'
 import ILucidePencil from '~icons/lucide/pencil'
 import ILucideSquare from '~icons/lucide/square'
@@ -124,7 +125,7 @@ function saveEdit() {
       }
     } catch (error) {
       // TODO: display a warning and stay in edit mode
-      console.error('Invalid JSON:', error)
+      diagnostics.PCD_R0013({ cause: error }, { method: 'error' })
       // cancelEdit()
       return
     }
@@ -134,7 +135,7 @@ function saveEdit() {
         try {
           newValue = BigInt(editValue.value)
         } catch (error) {
-          console.error('Invalid BigInt:', error)
+          diagnostics.PCD_R0014({ cause: error }, { method: 'error' })
           // TODO: display a warning
           return
         }
@@ -142,7 +143,7 @@ function saveEdit() {
       case 'number':
         newValue = Number(editValue.value)
         if (Number.isNaN(newValue)) {
-          console.error('Invalid number')
+          diagnostics.PCD_R0015({}, { method: 'error' })
           // TODO: display a warning
           return
         }

--- a/devtools/src/panel/composables/duplex-channel.ts
+++ b/devtools/src/panel/composables/duplex-channel.ts
@@ -7,6 +7,7 @@ import type {
 } from '@pinia/colada-devtools/shared'
 import { inject } from 'vue'
 import type { InjectionKey, Ref } from 'vue'
+import { diagnostics } from '../../diagnostics'
 
 export const DUPLEX_CHANNEL_KEY: InjectionKey<DuplexChannel<DevtoolsEmits, AppEmits>> =
   Symbol('duplex-channel')
@@ -14,9 +15,7 @@ export const DUPLEX_CHANNEL_KEY: InjectionKey<DuplexChannel<DevtoolsEmits, AppEm
 export function useDuplexChannel() {
   const channel = inject(DUPLEX_CHANNEL_KEY)
   if (!channel) {
-    throw new Error(
-      'The duplex channel is not provided. Make sure to use it inside the context of a component that provides it.',
-    )
+    throw diagnostics.PCD_R0006({ resource: 'duplex channel' })
   }
   return channel
 }
@@ -26,9 +25,7 @@ export const QUERIES_KEY: InjectionKey<Ref<UseQueryEntryPayload[]>> = Symbol('qu
 export function useQueryEntries() {
   const entries = inject(QUERIES_KEY)
   if (!entries) {
-    throw new Error(
-      'The query entries are not provided. Make sure to use it inside the context of a component that provides it.',
-    )
+    throw diagnostics.PCD_R0006({ resource: 'query entries' })
   }
   return entries
 }
@@ -38,9 +35,7 @@ export const MUTATIONS_KEY: InjectionKey<Ref<UseMutationEntryPayload[]>> = Symbo
 export function useMutationEntries() {
   const entries = inject(MUTATIONS_KEY)
   if (!entries) {
-    throw new Error(
-      'The mutation entries are not provided. Make sure to use it inside the context of a component that provides it.',
-    )
+    throw diagnostics.PCD_R0006({ resource: 'mutation entries' })
   }
   return entries
 }

--- a/devtools/src/panel/composables/use-container-media-query.ts
+++ b/devtools/src/panel/composables/use-container-media-query.ts
@@ -1,6 +1,7 @@
 import type { MaybeRefOrGetter } from 'vue'
 import { computed, onScopeDispose, shallowRef, toValue, watchEffect } from 'vue'
 import { useEventListener, useSupported } from '@vueuse/core'
+import { diagnostics } from '../../diagnostics'
 
 // copied from match-container and adapted to shadow DOM
 // import 'match-container'
@@ -60,7 +61,7 @@ class ContainerQueryList extends EventTarget {
 
     const rootNode = element.getRootNode()
     if (!(rootNode instanceof ShadowRoot) && !(rootNode instanceof Document)) {
-      console.error(`root node of element isn't a ShadowRoot or Document`, rootNode)
+      diagnostics.PCD_R0016({ cause: rootNode }, { method: 'error' })
       throw new TypeError('Root node must be a ShadowRoot or Document')
     }
 

--- a/devtools/src/panel/pages/queries/[queryId].vue
+++ b/devtools/src/panel/pages/queries/[queryId].vue
@@ -5,6 +5,7 @@ import { useDuplexChannel, useQueryEntries } from '../../composables/duplex-chan
 import { formatDuration } from '../../utils/time'
 import { useRoute } from 'vue-router'
 import type { DataStateStatus } from '@pinia/colada'
+import { diagnostics, formatDiagnosticValue } from '../../../diagnostics'
 
 import IWrench from '~icons/lucide/wrench'
 import IInfoCircle from '~icons/lucide/info'
@@ -79,7 +80,7 @@ watch(
 // Helper function to set nested value
 function setNestedValue(obj: any, path: Array<string | number>, value: unknown): boolean {
   if (path.length === 0) {
-    console.error('Cannot set value with empty path')
+    diagnostics.PCD_R0009({}, { method: 'error' })
     return false
   }
 
@@ -87,7 +88,10 @@ function setNestedValue(obj: any, path: Array<string | number>, value: unknown):
   // Navigate to parent of target value
   for (let i = 0; i < path.length - 1; i++) {
     if (current == null || typeof current !== 'object') {
-      console.error('Invalid path:', path, 'at index', i, 'Current value:', current)
+      diagnostics.PCD_R0010(
+        { path: formatDiagnosticValue(path), index: i, value: formatDiagnosticValue(current) },
+        { method: 'error' },
+      )
       return false
     }
     current = current[path[i]!]
@@ -95,7 +99,7 @@ function setNestedValue(obj: any, path: Array<string | number>, value: unknown):
 
   // Validate the final parent exists
   if (current == null || typeof current !== 'object') {
-    console.error('Invalid final parent in path:', path)
+    diagnostics.PCD_R0011({ path: formatDiagnosticValue(path) }, { method: 'error' })
     return false
   }
 
@@ -112,7 +116,7 @@ const handleValueUpdate = (path: Array<string | number>, value: unknown) => {
   const success = setNestedValue(selectedQuery.value.state.data, path, value)
 
   if (!success) {
-    console.error('Failed to update value at path:', path)
+    diagnostics.PCD_R0012({ path: formatDiagnosticValue(path) }, { method: 'error' })
     return
   }
 

--- a/devtools/src/shared/rpc/index.ts
+++ b/devtools/src/shared/rpc/index.ts
@@ -9,6 +9,7 @@ import type { UseMutationEntryPayload } from '../mutation-serialized'
 import { toRaw } from 'vue'
 import { restoreClonedDeep, safeSerialize } from './custom-values'
 import { isPlainObject } from '../json'
+import { diagnostics, formatDiagnosticValue } from '../../diagnostics'
 
 export { isNonSerializableValue } from './custom-values'
 export type { NonSerializableValue } from './custom-values'
@@ -43,7 +44,10 @@ export class DuplexChannel<
 
   private onMessage(event: MessageEvent) {
     if (!event.data || typeof event.data !== 'object' || typeof event.data.id !== 'string') {
-      console.error(`${this.constructor.name}: invalid message`, event.data)
+      diagnostics.PCD_R0007(
+        { channel: this.constructor.name, data: formatDiagnosticValue(event.data) },
+        { method: 'error' },
+      )
       return
     }
     const listeners = this.listenersByEvent.get(event.data.id)
@@ -56,7 +60,7 @@ export class DuplexChannel<
   }
 
   private onMessageError(event: MessageEvent) {
-    console.error(`${this.constructor.name}: message error`, event)
+    diagnostics.PCD_R0008({ channel: this.constructor.name, cause: event }, { method: 'error' })
   }
 
   stop() {

--- a/docs/.vitepress/config/index.ts
+++ b/docs/.vitepress/config/index.ts
@@ -271,6 +271,7 @@ On top of that Pinia Colada is highly extensible. You can create your own plugin
           items: [
             { text: 'Query Cache', link: '/advanced/query-cache.html' },
             { text: 'Reusable Queries', link: '/advanced/reusable-queries.html' },
+            { text: 'Diagnostics', link: '/diagnostics/' },
           ],
         },
         {

--- a/docs/diagnostics/index.md
+++ b/docs/diagnostics/index.md
@@ -1,0 +1,36 @@
+# Diagnostics
+
+Pinia Colada diagnostics are stable error and warning codes printed by the library in development. Each diagnostic explains what happened, how to fix it, and links to a dedicated page.
+
+## Runtime diagnostics
+
+- [PC_R0001](./pc_r0001.md): Pinia Colada could not find a Pinia instance.
+- [PC_R0002](./pc_r0002.md): The query cache was replaced directly.
+- [PC_R0003](./pc_r0003.md): `useQuery()` received an empty key array.
+- [PC_R0004](./pc_r0004.md): A query entry method was called without options.
+- [PC_R0005](./pc_r0005.md): A cache composable was called outside an injection context.
+- [PC_R0006](./pc_r0006.md): The mutation cache was replaced directly.
+- [PC_R0007](./pc_r0007.md): A mutation entry was mutated before being ensured.
+- [PC_R0008](./pc_r0008.md): A mutation entry was reused.
+- [PC_R0009](./pc_r0009.md): A defined mutation composable was called outside a scope.
+- [PC_R0010](./pc_r0010.md): An infinite query tried to load a previous page without `getPreviousPageParam`.
+- [PC_R0011](./pc_r0011.md): An infinite query tried to load more pages after its entry was missing.
+
+## Devtools diagnostics
+
+- [PCD_R0001](./pcd_r0001.md): A mutation replay target was not found.
+- [PCD_R0002](./pcd_r0002.md): A mutation replay target is being garbage collected.
+- [PCD_R0003](./pcd_r0003.md): A required devtools element was not found.
+- [PCD_R0004](./pcd_r0004.md): The devtools PiP window could not be opened.
+- [PCD_R0005](./pcd_r0005.md): The devtools element was not found after waiting.
+- [PCD_R0006](./pcd_r0006.md): A devtools injection was missing.
+- [PCD_R0007](./pcd_r0007.md): A devtools RPC message had an invalid shape.
+- [PCD_R0008](./pcd_r0008.md): A devtools RPC message could not be cloned or delivered.
+- [PCD_R0009](./pcd_r0009.md): The JSON editor tried to update an empty path.
+- [PCD_R0010](./pcd_r0010.md): The JSON editor path became invalid.
+- [PCD_R0011](./pcd_r0011.md): The JSON editor path parent became invalid.
+- [PCD_R0012](./pcd_r0012.md): The JSON editor failed to update a value.
+- [PCD_R0013](./pcd_r0013.md): The JSON editor received invalid JSON.
+- [PCD_R0014](./pcd_r0014.md): The JSON editor received an invalid BigInt.
+- [PCD_R0015](./pcd_r0015.md): The JSON editor received an invalid number.
+- [PCD_R0016](./pcd_r0016.md): A container media query element had an unsupported root node.

--- a/docs/diagnostics/pc_r0001.md
+++ b/docs/diagnostics/pc_r0001.md
@@ -1,0 +1,27 @@
+# PC_R0001
+
+Pinia Colada could not find a Pinia instance while installing the `PiniaColada` plugin.
+
+## How to fix it
+
+Install the Pinia plugin before Pinia Colada:
+
+```ts
+app.use(createPinia())
+app.use(PiniaColada)
+```
+
+If Pinia Colada must be installed before Pinia, pass the instance explicitly:
+
+```ts
+const pinia = createPinia()
+
+app.use(PiniaColada, { pinia })
+app.use(pinia)
+```
+
+## Common causes
+
+- `app.use(PiniaColada)` is called before `app.use(createPinia())`.
+- A custom app setup creates Pinia in one module but installs Pinia Colada in another.
+- Tests mount components with Pinia Colada but forget to install Pinia.

--- a/docs/diagnostics/pc_r0002.md
+++ b/docs/diagnostics/pc_r0002.md
@@ -1,0 +1,21 @@
+# PC_R0002
+
+The query cache was replaced directly. Query cache entries must be modified through cache methods so Pinia Colada can keep actions, plugins, and reactivity working.
+
+## How to fix it
+
+Use cache methods instead of assigning the cache map:
+
+```ts
+const queryCache = useQueryCache()
+
+queryCache.setQueryData(['contacts'], contacts)
+queryCache.invalidateQueries({ key: ['contacts'] })
+queryCache.remove(queryCache.get(['contacts'])!)
+```
+
+## Common causes
+
+- Assigning to `queryCache.caches` or replacing internal state during debugging.
+- Hydrating the raw cache map instead of using `hydrateQueryCache()`.
+- Mutating Pinia state with a full object replacement.

--- a/docs/diagnostics/pc_r0003.md
+++ b/docs/diagnostics/pc_r0003.md
@@ -1,0 +1,20 @@
+# PC_R0003
+
+`useQuery()` was called with an empty array as the key. Query keys uniquely identify cache entries and must contain at least one serializable element.
+
+## How to fix it
+
+Pass a stable, non-empty key:
+
+```ts
+useQuery({
+  key: ['contacts'],
+  query: () => fetch('/api/contacts').then((r) => r.json()),
+})
+```
+
+## Common causes
+
+- Building a key from an array that can become empty.
+- Using `[]` as a placeholder before the real key is known.
+- Trying to disable a query through the key instead of the `enabled` option.

--- a/docs/diagnostics/pc_r0004.md
+++ b/docs/diagnostics/pc_r0004.md
@@ -1,0 +1,23 @@
+# PC_R0004
+
+`entry.refresh()` or `entry.fetch()` was called on a query entry that has no options. Entries without options cannot run the query function again.
+
+## How to fix it
+
+Create the entry through `useQuery()`, `defineQuery()`, or `ensure()` with options before calling entry methods.
+
+```ts
+const queryCache = useQueryCache()
+const entry = queryCache.ensure({
+  key: ['contacts'],
+  query: () => fetch('/api/contacts').then((r) => r.json()),
+})
+
+await entry.refresh()
+```
+
+## Common causes
+
+- Prefetching or hydrating data without attaching query options.
+- Keeping an entry reference after code changed during development.
+- Calling low-level cache methods manually without ensuring the entry first.

--- a/docs/diagnostics/pc_r0005.md
+++ b/docs/diagnostics/pc_r0005.md
@@ -1,0 +1,23 @@
+# PC_R0005
+
+`useQueryCache()` or `useMutationCache()` was called outside a Vue injection context. These composables rely on Vue's `inject()` and must run where Vue provides app context.
+
+## How to fix it
+
+Call the cache composable from component setup, another composable used by setup, a Pinia store, or a navigation guard.
+
+```ts
+export function useContactsActions() {
+  const queryCache = useQueryCache()
+
+  return {
+    refreshContacts: () => queryCache.invalidateQueries({ key: ['contacts'] }),
+  }
+}
+```
+
+## Common causes
+
+- Calling `useQueryCache()` at module top level.
+- Calling cache composables inside an event handler that does not run from setup-created state.
+- Creating cache utilities outside the Vue app and reusing them across apps.

--- a/docs/diagnostics/pc_r0006.md
+++ b/docs/diagnostics/pc_r0006.md
@@ -1,0 +1,21 @@
+# PC_R0006
+
+The mutation cache was replaced directly. Mutation entries must be modified through cache methods so Pinia Colada can preserve reactivity and plugin hooks.
+
+## How to fix it
+
+Use mutation cache methods instead of assigning the cache map:
+
+```ts
+const mutationCache = useMutationCache()
+const entry = mutationCache.create(options)
+
+mutationCache.ensure(entry, vars)
+await mutationCache.mutate(entry)
+```
+
+## Common causes
+
+- Replacing internal Pinia state during debugging.
+- Trying to clear all mutations by assigning a new map.
+- Mutating serialized state instead of calling cache APIs.

--- a/docs/diagnostics/pc_r0007.md
+++ b/docs/diagnostics/pc_r0007.md
@@ -1,0 +1,20 @@
+# PC_R0007
+
+A mutation entry was passed to `mutationCache.mutate()` before it was ensured. Ensuring assigns the mutation id, key, and variables used by plugins and cache tracking.
+
+## How to fix it
+
+Ensure the entry before mutating it manually:
+
+```ts
+const mutationCache = useMutationCache()
+const entry = mutationCache.create(options)
+
+await mutationCache.mutate(mutationCache.ensure(entry, vars))
+```
+
+## Common causes
+
+- Calling the low-level mutation cache manually.
+- Creating an entry and immediately mutating it without `ensure()`.
+- Reusing internal mutation code outside `useMutation()`.

--- a/docs/diagnostics/pc_r0008.md
+++ b/docs/diagnostics/pc_r0008.md
@@ -1,0 +1,21 @@
+# PC_R0008
+
+A mutation entry was reused after it had already started or completed. Each manual mutation call should use a freshly ensured entry.
+
+## How to fix it
+
+Ensure the entry for each manual mutation:
+
+```ts
+const mutationCache = useMutationCache()
+
+await mutationCache.mutate(mutationCache.ensure(entry, vars))
+```
+
+If the entry already ran, create a new entry before ensuring it again.
+
+## Common causes
+
+- Calling `mutationCache.mutate(entry)` multiple times on the same entry.
+- Reusing an entry while its async status is still loading.
+- Manually bypassing `useMutation()`, which normally handles this for you.

--- a/docs/diagnostics/pc_r0009.md
+++ b/docs/diagnostics/pc_r0009.md
@@ -1,0 +1,26 @@
+# PC_R0009
+
+A composable returned by `defineMutation()` was called outside a component or effect scope. Pinia Colada cannot automatically clean up the mutation effects in that case.
+
+## How to fix it
+
+Call the defined mutation composable inside component setup, an effect scope, or a Pinia store:
+
+```ts
+const useCreateContact = defineMutation({
+  mutation: createContact,
+})
+
+export default {
+  setup() {
+    const createContactMutation = useCreateContact()
+    return { createContactMutation }
+  },
+}
+```
+
+## Common causes
+
+- Calling the returned composable at module top level.
+- Creating a singleton mutation outside the app lifecycle.
+- Calling the composable from plain utility code instead of setup-owned code.

--- a/docs/diagnostics/pc_r0010.md
+++ b/docs/diagnostics/pc_r0010.md
@@ -1,0 +1,23 @@
+# PC_R0010
+
+An infinite query tried to load a previous page, but `getPreviousPageParam` was not defined. Without that option, Pinia Colada cannot compute the previous page parameter.
+
+## How to fix it
+
+Add `getPreviousPageParam` when previous-page loading is possible:
+
+```ts
+useInfiniteQuery({
+  key: ['messages'],
+  initialPageParam: 1,
+  query: ({ pageParam }) => fetchMessages(pageParam),
+  getNextPageParam: (lastPage) => lastPage.next,
+  getPreviousPageParam: (firstPage) => firstPage.previous,
+})
+```
+
+## Common causes
+
+- Calling `loadPreviousPage()` on a next-page-only infinite query.
+- Defining `getNextPageParam` but forgetting the reverse direction.
+- Rendering a previous-page button without checking `hasPreviousPage`.

--- a/docs/diagnostics/pc_r0011.md
+++ b/docs/diagnostics/pc_r0011.md
@@ -1,0 +1,23 @@
+# PC_R0011
+
+An infinite query tried to load more pages, but its query entry was not found in the cache. Pinia Colada cannot fetch another page without the entry and its options.
+
+## How to fix it
+
+Make sure the infinite query is mounted and initialized before calling `loadNextPage()` or `loadPreviousPage()`.
+
+```ts
+const query = useInfiniteQuery(options)
+
+async function loadMore() {
+  if (query.status.value !== 'pending') {
+    await query.loadNextPage()
+  }
+}
+```
+
+## Common causes
+
+- Calling a load-more method after the component that owns the query unmounted.
+- Removing the query entry from the cache before loading another page.
+- Keeping a stale reference to a query returned by a previous component instance.

--- a/docs/diagnostics/pcd_r0001.md
+++ b/docs/diagnostics/pcd_r0001.md
@@ -1,0 +1,13 @@
+# PCD_R0001
+
+The devtools tried to replay a mutation, but the mutation entry was not found.
+
+## How to fix it
+
+Select a mutation that is still present in the devtools mutation list before replaying it.
+
+## Common causes
+
+- The mutation entry was removed from the cache.
+- The app refreshed or re-created the mutation cache.
+- A stale devtools panel action targeted an old mutation id.

--- a/docs/diagnostics/pcd_r0002.md
+++ b/docs/diagnostics/pcd_r0002.md
@@ -1,0 +1,13 @@
+# PCD_R0002
+
+The devtools tried to replay a mutation that is already being garbage collected.
+
+## How to fix it
+
+Replay an active mutation entry, or trigger the mutation again from the application.
+
+## Common causes
+
+- The component that used the mutation was unmounted.
+- The mutation entry reached its configured `gcTime`.
+- The mutation is no longer referenced anywhere in the app.

--- a/docs/diagnostics/pcd_r0003.md
+++ b/docs/diagnostics/pcd_r0003.md
@@ -1,0 +1,13 @@
+# PCD_R0003
+
+The devtools could not find a required Pinia Colada devtools element.
+
+## How to fix it
+
+Make sure the Pinia Colada devtools custom element is mounted before opening or moving the panel window.
+
+## Common causes
+
+- The devtools wrapper has not finished mounting.
+- The custom element was removed from the DOM.
+- The element exists but its shadow root or root node is missing.

--- a/docs/diagnostics/pcd_r0004.md
+++ b/docs/diagnostics/pcd_r0004.md
@@ -1,0 +1,13 @@
+# PCD_R0004
+
+The devtools could not open its picture-in-picture window.
+
+## How to fix it
+
+Allow popups for the current page, then try opening the Pinia Colada devtools window again.
+
+## Common causes
+
+- The browser blocked `window.open()`.
+- The call was not triggered by a direct user interaction.
+- The environment does not allow popup windows.

--- a/docs/diagnostics/pcd_r0005.md
+++ b/docs/diagnostics/pcd_r0005.md
@@ -1,0 +1,13 @@
+# PCD_R0005
+
+The devtools waited for its root element but could not find it.
+
+## How to fix it
+
+Reload the page and make sure the Pinia Colada devtools wrapper is mounted.
+
+## Common causes
+
+- The devtools script loaded before the wrapper element existed.
+- The wrapper failed to mount.
+- Another script removed the devtools element.

--- a/docs/diagnostics/pcd_r0006.md
+++ b/docs/diagnostics/pcd_r0006.md
@@ -1,0 +1,13 @@
+# PCD_R0006
+
+A devtools composable was used without the required provided value.
+
+## How to fix it
+
+Render the composable under the devtools provider component that provides the required injection key.
+
+## Common causes
+
+- A devtools panel component was mounted outside the panel shell.
+- A test renders a child component without its providers.
+- The provider setup failed before rendering the child component.

--- a/docs/diagnostics/pcd_r0007.md
+++ b/docs/diagnostics/pcd_r0007.md
@@ -1,0 +1,13 @@
+# PCD_R0007
+
+The devtools RPC channel received a message that was not an object with a string `id`.
+
+## How to fix it
+
+Send RPC messages as objects with a string `id` and serialized data payload.
+
+## Common causes
+
+- A `MessagePort` was shared with non-devtools code.
+- A malformed custom devtools integration posted to the channel.
+- Serialized data was replaced before reaching the receiver.

--- a/docs/diagnostics/pcd_r0008.md
+++ b/docs/diagnostics/pcd_r0008.md
@@ -1,0 +1,13 @@
+# PCD_R0008
+
+The devtools RPC channel received a `messageerror` event.
+
+## How to fix it
+
+Check that all RPC payload values can be cloned through `MessagePort`.
+
+## Common causes
+
+- A payload contains a value unsupported by structured clone.
+- A custom value serializer returned a non-cloneable value.
+- The browser failed to transfer a message between the app and panel.

--- a/docs/diagnostics/pcd_r0009.md
+++ b/docs/diagnostics/pcd_r0009.md
@@ -1,0 +1,13 @@
+# PCD_R0009
+
+The devtools JSON editor tried to update a value with an empty path.
+
+## How to fix it
+
+Select a nested value in the JSON editor before applying an update.
+
+## Common causes
+
+- The edited field was removed before the save action ran.
+- A custom editor action sent an empty path.
+- The selected query data changed while editing.

--- a/docs/diagnostics/pcd_r0010.md
+++ b/docs/diagnostics/pcd_r0010.md
@@ -1,0 +1,13 @@
+# PCD_R0010
+
+The devtools JSON editor path became invalid before the update reached its target.
+
+## How to fix it
+
+Edit an existing object or array path, or refresh the query entry before editing.
+
+## Common causes
+
+- Query data changed while a value was being edited.
+- A parent object was replaced by a primitive value.
+- The selected entry no longer matches the visible JSON tree.

--- a/docs/diagnostics/pcd_r0011.md
+++ b/docs/diagnostics/pcd_r0011.md
@@ -1,0 +1,13 @@
+# PCD_R0011
+
+The devtools JSON editor found the target path, but the final parent is no longer an object or array.
+
+## How to fix it
+
+Edit a path whose parent is still an object or array.
+
+## Common causes
+
+- The parent value changed while editing.
+- The edited path points into a primitive value.
+- The query entry was refreshed with different data.

--- a/docs/diagnostics/pcd_r0012.md
+++ b/docs/diagnostics/pcd_r0012.md
@@ -1,0 +1,13 @@
+# PCD_R0012
+
+The devtools JSON editor failed to update a value at the selected path.
+
+## How to fix it
+
+Refresh the selected query entry and retry the edit.
+
+## Common causes
+
+- The selected entry changed while editing.
+- The path no longer exists in the query data.
+- A previous validation diagnostic prevented the update.

--- a/docs/diagnostics/pcd_r0013.md
+++ b/docs/diagnostics/pcd_r0013.md
@@ -1,0 +1,13 @@
+# PCD_R0013
+
+The devtools JSON editor could not parse the edited value as JSON.
+
+## How to fix it
+
+Enter valid JSON, or use the explicit `undefined` value when editing an undefined value.
+
+## Common causes
+
+- A string value is missing quotes.
+- An object has a trailing comma.
+- The value uses JavaScript syntax that is not valid JSON.

--- a/docs/diagnostics/pcd_r0014.md
+++ b/docs/diagnostics/pcd_r0014.md
@@ -1,0 +1,13 @@
+# PCD_R0014
+
+The devtools JSON editor could not parse the edited value as a BigInt.
+
+## How to fix it
+
+Enter a valid BigInt string without decimal points or separators.
+
+## Common causes
+
+- The value contains a decimal point.
+- The value contains whitespace or separators.
+- The value is empty.

--- a/docs/diagnostics/pcd_r0015.md
+++ b/docs/diagnostics/pcd_r0015.md
@@ -1,0 +1,13 @@
+# PCD_R0015
+
+The devtools JSON editor could not parse the edited value as a number.
+
+## How to fix it
+
+Enter a value that JavaScript can parse as a finite number.
+
+## Common causes
+
+- The value is not numeric text.
+- The value is empty.
+- The value contains formatting characters.

--- a/docs/diagnostics/pcd_r0016.md
+++ b/docs/diagnostics/pcd_r0016.md
@@ -1,0 +1,13 @@
+# PCD_R0016
+
+The devtools container media query helper received an element whose root node is not a `ShadowRoot` or `Document`.
+
+## How to fix it
+
+Pass an element attached to a document or shadow root.
+
+## Common causes
+
+- The element was detached before the helper ran.
+- A test passed a mocked element with an unsupported root node.
+- The helper was called before the element mounted.

--- a/package.json
+++ b/package.json
@@ -104,6 +104,9 @@
     "vitest": "^4.1.5",
     "vue": "^3.5.33"
   },
+  "dependencies": {
+    "nostics": "^0.4.0"
+  },
   "peerDependencies": {
     "pinia": "^2.2.6 || ^3.0.0",
     "vue": "^3.5.17"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      nostics:
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@ast-grep/cli':
         specifier: ^0.42.1
@@ -1780,8 +1784,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    resolution: {integrity: sha512-KrLaPWa5c9Y7LkW+rKkaUE3y7DBDrQtaf7rlsSDfv6KAHUjgzAIRA761Lrrp6//Yd/Rlie/yEOt9YENCoJnOcw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
   '@oxc-parser/binding-android-arm64@0.117.0':
     resolution: {integrity: sha512-EPTs2EBijGmyhPso4rXAL0NSpECXER9IaVKFZEv83YcA6h4uhKW47kmYt+OZcSp130zhHx+lTWILDQ/LDkCRNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
+    resolution: {integrity: sha512-SThDrSeamB/kG2+NxcJ5/wSLcV6dUqDknrPLqFYQ0ST/55mtBP4M7Q/f3QbubH6aAd11wpzZn/nwbVRSdobOpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
@@ -1792,8 +1808,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    resolution: {integrity: sha512-Lc0f/TYoKBghE5/2Gsv7bLXk+TJZunx2Tf61X8hG4ARXdc8UYI26dCGccFSd1AyFbK3jfaNXtMnupggDbjPXdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-parser/binding-darwin-x64@0.117.0':
     resolution: {integrity: sha512-W7S99zFwVZhSbCxvjfZkioStFU249DBc4TJw/kK6kfKwx2Zew+jvizX5Y3ZPkAh7fBVUSNOdSeOqLBHLiP50tw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
+    resolution: {integrity: sha512-RG2eJIpf7C21z9HSSXFw1bTArdpKe7Y4fwcJTwRq1yCSe1vSavaN9GA1sm9KqzemTLAGVktQ+7qBTGp0vQeUZg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
@@ -1804,8 +1832,20 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    resolution: {integrity: sha512-wQIPntPLtJ8NcBpvKPbEv3NqzV6k8eP8tP/jE9Rg8HTg/j7urZGFSsTCPCW5k77Qfw2DM4vRvc9p3I4yq/Shvw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
     resolution: {integrity: sha512-9Hdm1imzrn4RdMYnQKKcy+7p7QsSPIrgVIZmpGSJT02nYDuBWLdG1pdYMPFoEo46yiXry3tS3RoHIpNbT1IiyQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
+    resolution: {integrity: sha512-PixKEpeSe3yxQWqNyOCBALRYc72+Tj7ILDofUl3iXo25cVOzLA6jHUhmOINRtWIPh7dbUie3QNeabwaQpZTw6w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -1816,8 +1856,21 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    resolution: {integrity: sha512-sCR+DzGHlyHKnbA2z9zWjTUhIo8Sy0enJl4RDsBwPmkxYynPatpwOAWe8W5127SlW0boqUWHGtr1NWn5UwIhXQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
     resolution: {integrity: sha512-jBxD7DtlHQ36ivjjZdH0noQJgWNouenzpLmXNKnYaCsBfo3jY95m5iyjYQEiWkvkhJ3TJUAs7tQ1/kEpY7x/Kg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
+    resolution: {integrity: sha512-sQBix5P2cW+IpzTcCwYxnh9yALrKSIkKJThspBvMGcygSMnbzkSvhN7SfuX1hvBk8y1XEChsdkU3ET0V5DmzUw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -1830,8 +1883,22 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    resolution: {integrity: sha512-WozHg3Kc//8Sk756HXXgMbEAvqtG+Lzb9JOojwQzIGDtN78Az2dLttkb71akWYUF/8IgYfDSlfKh4Uot8is5Vw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
     resolution: {integrity: sha512-RPddpcE/0xxWaommWy0c5i/JdrXcXAkxBS2GOrAUh5LKmyCh03hpJedOAWszG4ADsKQwoUQQ1/tZVGRhZIWtKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
+    resolution: {integrity: sha512-CmX/ulNBOEwWTyVRmcpYKAcAizW6+OjtLJgo7fXoL9OqQvjF4VER8tPomv44vwzfSCy1BHbsB0ZlZYzYJNj4cA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
@@ -1844,8 +1911,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    resolution: {integrity: sha512-j9oQS+hM90SdhviNGWbPgT4+Rlq+ac++q/zjgwPD1mVHgxHzATvoRGtDx0sXGmFOQ9J9YkwAhYGb5MAHL6TAsA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
     resolution: {integrity: sha512-ujGcAx8xAMvhy7X5sBFi3GXML1EtyORuJZ5z2T6UV3U416WgDX/4OCi3GnoteeenvxIf6JgP45B+YTHpt71vpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
+    resolution: {integrity: sha512-bLz+Xi+Agnfmd7kWPEsSVwCn2k4EyIalZkNBcQ0OGIv9rqn8VgCPLNd03tM9mKX/5TdlvDXalz0q71BIrOPNqg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
@@ -1858,8 +1939,22 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    resolution: {integrity: sha512-U6t2qbJU0ypTfyj9QV3W1Y6mITDTL8ai/OR6NUn85vyHthOvobKWgXzU4tu0EskSzlpuVFz1g0jFGulDIUKHxQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
     resolution: {integrity: sha512-1QrTrf8rige7UPJrYuDKJLQOuJlgkt+nRSJLBMHWNm9TdivzP48HaK3f4q18EjNlglKtn03lgjMu4fryDm8X4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
+    resolution: {integrity: sha512-WcEaSNHFk8yz5YFlQQAlhq6jOFmZBB/RKE7uzhyCIf+pF1Lmv9gUH4221mle2Gd9iHyWT3ySNph8yZgb1xYdWg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -1872,8 +1967,21 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    resolution: {integrity: sha512-iQrV4iJzQgRwK3BWRmQl1C3C6g3wYpXN2WLdQdyR+efoUnncdShZAVp9OgcojtlD3MDRbuOMGG3SjxF4fL4nlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
     resolution: {integrity: sha512-QPJvFbnnDZZY7xc+xpbIBWLThcGBakwaYA9vKV8b3+oS5MGfAZUoTFJcix5+Zg2Ri46sOfrUim6Y6jsKNcssAQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
+    resolution: {integrity: sha512-FWzmUGrZ6GUby4U7WIwcCtab6tdmlTO3xTRRKyb5kjIJVEiaUAT8animUG/nK8ZCA8gkRkPOTId4rl6uTqUmJQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
@@ -1883,8 +1991,19 @@ packages:
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    resolution: {integrity: sha512-TlbMppxJI5CjWDes0QaP6G3aneVg1yikBu5QYI+DUShF9WDL66ccgKFNNGmi/Wybtszw6hxwAvv76T4DaPKnHw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
     resolution: {integrity: sha512-GpxeGS+Vo030DsrXeRPc7OSJOQIyAHkM3mzwBcnQjg/79XnOIDDMXJ5X6/aNdkVt/+Pv35pqKzGA4TQau97x8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
+    resolution: {integrity: sha512-RH/NbFjGKqdUAUi7Oh3LQPxUk2hsWFEEQ38HSnbRQT8QjBZFKqL1fMbmsB3N4jy/KPh9iX94+9dmkEMBBbambw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
@@ -1895,8 +2014,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    resolution: {integrity: sha512-JUr4jQY9jxoIB/YTLXr6XofSi5xikj6p5/Ns1h0VOBDT0j1jKU+kMsv2xxv51RwnETcXpA1Yw/9oUAfcqfaqEA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
     resolution: {integrity: sha512-ysRJAjIbB4e5y+t9PZs7TwbgOV/GVT//s30AORLCT/pedYwpYzHq6ApXK7is9fvyfZtgT3anNir8+esurmyaDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
+    resolution: {integrity: sha512-2dapgHpA5X8DSXF4AU36hJWYf6zP0tKjMXFRAZFBD62pkevW/uhFDXoFH9Y/3Fd2EtDrw5ByNnR1wVE9X9y0SQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
@@ -1909,6 +2040,9 @@ packages:
 
   '@oxc-project/types@0.129.0':
     resolution: {integrity: sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==}
+
+  '@oxc-project/types@0.132.0':
+    resolution: {integrity: sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==}
 
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
     resolution: {integrity: sha512-17giX7h5VR9Eodru4OoSCFdgwLFIaUxeEn8JWe0vMZrAuRbT9NiDTy5dXdbGQBoO8aXPkbGS38FGlvbi31aujw==}
@@ -5837,6 +5971,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nostics@0.4.0:
+    resolution: {integrity: sha512-HjGay1njIki+R6zAUnKfxDVRrDcvy0ELPCj+5b/KbolnGKjOGxBNEd28Hn5ziiIuodFv034nLYUW/szFOiy2Iw==}
+
   npm-normalize-package-bin@6.0.0:
     resolution: {integrity: sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
@@ -5958,6 +6095,10 @@ packages:
 
   oxc-parser@0.117.0:
     resolution: {integrity: sha512-l3cbgK5wUvWDVNWM/JFU77qDdGZK1wudnLsFcrRyNo/bL1CyU8pC25vDhMHikVY29lbK2InTWsX42RxVSutUdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-parser@0.132.0:
+    resolution: {integrity: sha512-+0LAPHaqtfQlvWdpaAa09SmOaZZgP8C552xosEkGJ4+ruEwP1Vgx+sqBgcBCNfR6KDCmagGOZTde8wmAvcI/Hg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-transform@0.117.0:
@@ -9209,49 +9350,97 @@ snapshots:
   '@oxc-parser/binding-android-arm-eabi@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-android-arm-eabi@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-android-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-darwin-arm64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-arm64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-darwin-x64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-freebsd-x64@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-freebsd-x64@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm-musleabihf@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm-musleabihf@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-ppc64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-riscv64-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-riscv64-musl@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-s390x-gnu@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-s390x-gnu@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-gnu@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.132.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-musl@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-musl@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-openharmony-arm64@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.132.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
@@ -9262,13 +9451,29 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.132.0':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.132.0':
     optional: true
 
   '@oxc-parser/binding-win32-ia32-msvc@0.117.0':
     optional: true
 
+  '@oxc-parser/binding-win32-ia32-msvc@0.132.0':
+    optional: true
+
   '@oxc-parser/binding-win32-x64-msvc@0.117.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.132.0':
     optional: true
 
   '@oxc-project/types@0.117.0': {}
@@ -9276,6 +9481,8 @@ snapshots:
   '@oxc-project/types@0.127.0': {}
 
   '@oxc-project/types@0.129.0': {}
+
+  '@oxc-project/types@0.132.0': {}
 
   '@oxc-transform/binding-android-arm-eabi@0.117.0':
     optional: true
@@ -13177,6 +13384,12 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  nostics@0.4.0:
+    dependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.132.0
+      unplugin: 3.0.0
+
   npm-normalize-package-bin@6.0.0: {}
 
   npm-run-all2@9.0.1:
@@ -13478,6 +13691,31 @@ snapshots:
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
+
+  oxc-parser@0.132.0:
+    dependencies:
+      '@oxc-project/types': 0.132.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.132.0
+      '@oxc-parser/binding-android-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-arm64': 0.132.0
+      '@oxc-parser/binding-darwin-x64': 0.132.0
+      '@oxc-parser/binding-freebsd-x64': 0.132.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.132.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.132.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.132.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.132.0
+      '@oxc-parser/binding-linux-x64-musl': 0.132.0
+      '@oxc-parser/binding-openharmony-arm64': 0.132.0
+      '@oxc-parser/binding-wasm32-wasi': 0.132.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.132.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.132.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.132.0
 
   oxc-transform@0.117.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,10 @@ importers:
         version: 3.5.33(typescript@6.0.3)
 
   devtools:
+    dependencies:
+      nostics:
+        specifier: ^0.4.0
+        version: 0.4.0
     devDependencies:
       '@iconify-json/lucide':
         specifier: ^1.2.104

--- a/src/define-mutation.ts
+++ b/src/define-mutation.ts
@@ -5,6 +5,7 @@ import { useMutation } from './use-mutation'
 import type { UseMutationReturn } from './use-mutation'
 import type { UseMutationOptions } from './mutation-options'
 import type { _EmptyObject } from './utils'
+import { diagnostics } from './diagnostics'
 
 /**
  * Define a mutation with the given options. Similar to `useMutation(options)` but allows you to reuse the mutation in
@@ -74,9 +75,7 @@ export function defineMutation(
         }
       })
     } else if (process.env.NODE_ENV !== 'production') {
-      console.warn(
-        `[@pinia/colada]: defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks. Make sure to call it inside a component setup, an effect scope, or a store.`,
-      )
+      diagnostics.PC_R0009()
     }
 
     return ret

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,0 +1,56 @@
+import { createConsoleReporter, defineDiagnostics } from 'nostics'
+
+export const diagnostics = /*#__PURE__*/ defineDiagnostics({
+  docsBase: (code) => `https://pinia-colada.esm.dev/diagnostics/${code.toLowerCase()}`,
+  reporters: [/*#__PURE__*/ createConsoleReporter()],
+  codes: {
+    PC_R0001: {
+      why: '[@pinia/colada] root pinia plugin not detected. Make sure you install pinia before installing the "PiniaColada" plugin or to manually pass the pinia instance.',
+      fix: 'Install the Pinia plugin before Pinia Colada, or pass the Pinia instance with the pinia option.',
+    },
+    PC_R0002: {
+      why: '[@pinia/colada] The query cache cannot be directly set, it must be modified only. This will fail on production',
+      fix: 'Use query cache methods such as setQueryData(), invalidateQueries(), or remove() instead of replacing the cache map.',
+    },
+    PC_R0003: {
+      why: 'useQuery() was called with an empty array as the key. It must have at least one element.',
+      fix: 'Pass a stable key with at least one serializable element, for example ["todos"].',
+    },
+    PC_R0004: {
+      why: (p: { method: 'refresh' | 'fetch' }) =>
+        `"entry.${p.method}()" was called but the entry has no options. This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!`,
+      fix: 'Create the entry through useQuery(), defineQuery(), or ensure() with options before calling this method.',
+    },
+    PC_R0005: {
+      why: (p: { composable: 'useQueryCache' | 'useMutationCache' }) =>
+        `${p.composable}() was called outside of an injection context (component setup, store, navigation guard) You will get a warning about "inject" being used incorrectly from Vue. Make sure to use it only in allowed places.\nSee https://vuejs.org/guide/reusability/composables.html#usage-restrictions`,
+      fix: 'Call this composable from component setup, a store, a navigation guard, or another Vue injection context.',
+    },
+    PC_R0006: {
+      why: '[@pinia/colada]: The mutation cache instance cannot be set directly, it must be modified. This will fail in production.',
+      fix: 'Use mutation cache methods such as ensure(), mutate(), remove(), or setEntryState() instead of replacing the cache map.',
+    },
+    PC_R0007: {
+      why: (p: { keyMessage: string }) =>
+        `[@pinia/colada] A mutation entry ${p.keyMessage} was mutated before being ensured. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
+      fix: 'Call mutationCache.mutate(mutationCache.ensure(entry, vars)) when mutating entries manually.',
+    },
+    PC_R0008: {
+      why: (p: { keyMessage: string }) =>
+        `[@pinia/colada] A mutation entry ${p.keyMessage} was reused. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
+      fix: 'Create or ensure a fresh mutation entry before each manual mutation call.',
+    },
+    PC_R0009: {
+      why: '[@pinia/colada]: defineMutation() composable was called outside of a component or effect scope. The mutation effects will never be cleaned up, which may cause memory leaks. Make sure to call it inside a component setup, an effect scope, or a store.',
+      fix: 'Call the returned mutation composable inside component setup, an effect scope, or a Pinia store.',
+    },
+    PC_R0010: {
+      why: '[useInfiniteQuery] Trying to load previous page but `getPreviousPageParam` is not defined in options. This will fail in production.',
+      fix: 'Define getPreviousPageParam when calling useInfiniteQuery() if previous pages can be loaded.',
+    },
+    PC_R0011: {
+      why: '[useInfiniteQuery] Cannot load next page: query entry not found in cache.',
+      fix: 'Make sure the infinite query is mounted and its cache entry exists before loading more pages.',
+    },
+  },
+})

--- a/src/infinite-query.ts
+++ b/src/infinite-query.ts
@@ -7,6 +7,7 @@ import { useQueryCache, type QueryCache, type UseQueryEntry } from './query-stor
 import { noop, toValueWithArgs } from './utils'
 import type { _RemoveMaybeRef } from './utils'
 import type { EntryKey, EntryKeyTagged } from './entry-keys'
+import { diagnostics } from './diagnostics'
 
 /**
  * Structure of data stored for infinite queries.
@@ -425,10 +426,7 @@ export function useInfiniteQuery<
 
             if (process.env.NODE_ENV !== 'production') {
               if (position === 0 && !opts.getPreviousPageParam) {
-                const msg =
-                  '[useInfiniteQuery] Trying to load previous page but `getPreviousPageParam` is not defined in options. This will fail in production.'
-                console.warn(msg)
-                throw new Error(msg)
+                throw diagnostics.PC_R0010()
               }
             }
 
@@ -528,7 +526,7 @@ export function useInfiniteQuery<
     const entry = queryCache.get(toValue(opts.key))
     if (!entry) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('[useInfiniteQuery] Cannot load next page: query entry not found in cache.')
+        diagnostics.PC_R0011()
       }
       return null
     }

--- a/src/mutation-store.ts
+++ b/src/mutation-store.ts
@@ -12,7 +12,7 @@ import type { App, EffectScope, ShallowRef } from 'vue'
 import { find } from './entry-keys'
 import type { EntryFilter } from './entry-filter'
 import type { _EmptyObject } from './utils'
-import { noop, toValueWithArgs, warnOnce } from './utils'
+import { noop, reportOnce, toValueWithArgs } from './utils'
 import type { _ReduceContext } from './use-mutation'
 import { useMutationOptions } from './mutation-options'
 import type {
@@ -22,6 +22,7 @@ import type {
 } from './mutation-options'
 import type { EntryKey } from './entry-keys'
 import type { MutationMeta } from './types-extension'
+import { diagnostics } from './diagnostics'
 
 /**
  * Allows defining extensions to the mutation entry that are returned by `useMutation()`.
@@ -137,9 +138,7 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
           set:
             process.env.NODE_ENV !== 'production'
               ? () => {
-                  console.error(
-                    `[@pinia/colada]: The mutation cache instance cannot be set directly, it must be modified. This will fail in production.`,
-                  )
+                  diagnostics.PC_R0006({}, { method: 'error' })
                 }
               : noop,
         },
@@ -151,10 +150,9 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
 
   if (process.env.NODE_ENV !== 'production') {
     if (!hasInjectionContext()) {
-      warnOnce(
-        `useMutationCache() was called outside of an injection context (component setup, store, navigation guard) You will get a warning about "inject" being used incorrectly from Vue. Make sure to use it only in allowed places.\n` +
-          `See https://vuejs.org/guide/reusability/composables.html#usage-restrictions`,
-      )
+      reportOnce('useMutationCache:outside-injection-context', () => {
+        diagnostics.PC_R0005({ composable: 'useMutationCache' })
+      })
     }
   }
 
@@ -398,18 +396,14 @@ export const useMutationCache = /* @__PURE__ */ defineStore(MUTATION_STORE_ID, (
       const key = entry.key?.join('/')
       const keyMessage = key ? `with key "${key}"` : 'without a key'
       if (entry.id === 0) {
-        console.error(
-          `[@pinia/colada] A mutation entry ${keyMessage} was mutated before being ensured. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first If not, this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
-        )
+        diagnostics.PC_R0007({ keyMessage }, { method: 'error' })
       }
       if (
         // the entry has already an ongoing request
         entry.state.value.status !== 'pending' ||
         entry.asyncStatus.value === 'loading'
       ) {
-        console.error(
-          `[@pinia/colada] A mutation entry ${keyMessage} was reused. If you are manually calling the "mutationCache.mutate()", you should always ensure the entry first: "mutationCache.mutate(mutationCache.ensure(entry, vars))". If not this is probably a bug. Please, open an issue on GitHub with a boiled down reproduction.`,
-        )
+        diagnostics.PC_R0008({ keyMessage }, { method: 'error' })
       }
     }
 

--- a/src/pinia-colada.ts
+++ b/src/pinia-colada.ts
@@ -6,6 +6,7 @@ import { useQueryCache } from './query-store'
 import type { PiniaColadaPlugin } from './plugins'
 import { USE_MUTATION_DEFAULTS, USE_MUTATION_OPTIONS_KEY } from './mutation-options'
 import type { UseMutationOptionsGlobal } from './mutation-options'
+import { diagnostics } from './diagnostics'
 
 /**
  * Options for the Pinia Colada plugin.
@@ -62,9 +63,7 @@ export const PiniaColada: Plugin<[options?: PiniaColadaOptions]> = (
   })
 
   if (process.env.NODE_ENV !== 'production' && !pinia) {
-    throw new Error(
-      '[@pinia/colada] root pinia plugin not detected. Make sure you install pinia before installing the "PiniaColada" plugin or to manually pass the pinia instance.',
-    )
+    throw diagnostics.PC_R0001()
   }
 
   // install plugins

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -18,7 +18,8 @@ import type { UseQueryOptions, UseQueryOptionsWithDefaults } from './query-optio
 import type { EntryFilter } from './entry-filter'
 import { find, START_EXT, toCacheKey } from './entry-keys'
 import type { ErrorDefault, QueryMeta } from './types-extension'
-import { toValueWithArgs, warnOnce } from './utils'
+import { reportOnce, toValueWithArgs } from './utils'
+import { diagnostics } from './diagnostics'
 
 /**
  * Allows defining extensions to the query entry that are returned by `useQuery()`.
@@ -247,9 +248,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       () => caches.value !== cachesRaw,
       (isDifferent) => {
         if (isDifferent) {
-          console.error(
-            `[@pinia/colada] The query cache cannot be directly set, it must be modified only. This will fail on production`,
-          )
+          diagnostics.PC_R0002({}, { method: 'error' })
         }
       },
     )
@@ -265,10 +264,9 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
 
   if (process.env.NODE_ENV !== 'production') {
     if (!hasInjectionContext()) {
-      warnOnce(
-        `useQueryCache() was called outside of an injection context (component setup, store, navigation guard) You will get a warning about "inject" being used incorrectly from Vue. Make sure to use it only in allowed places.\n` +
-          `See https://vuejs.org/guide/reusability/composables.html#usage-restrictions`,
-      )
+      reportOnce('useQueryCache:outside-injection-context', () => {
+        diagnostics.PC_R0005({ composable: 'useQueryCache' })
+      })
     }
   }
 
@@ -517,9 +515,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       const keyHash = toCacheKey(key)
 
       if (process.env.NODE_ENV !== 'production' && keyHash === '[]') {
-        throw new Error(
-          `useQuery() was called with an empty array as the key. It must have at least one element.`,
-        )
+        throw diagnostics.PC_R0003()
       }
 
       // do not reinitialize the entry
@@ -648,9 +644,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       options = entry.options,
     ): Promise<DataState<TData, TError, TDataInitial>> => {
       if (process.env.NODE_ENV !== 'production' && !options) {
-        throw new Error(
-          `"entry.refresh()" was called but the entry has no options. This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!`,
-        )
+        throw diagnostics.PC_R0004({ method: 'refresh' })
       }
 
       if (entry.state.value.error || entry.stale) {
@@ -673,9 +667,7 @@ export const useQueryCache = /* @__PURE__ */ defineStore(QUERY_STORE_ID, ({ acti
       options = entry.options,
     ): Promise<DataState<TData, TError, TDataInitial>> => {
       if (process.env.NODE_ENV !== 'production' && !options) {
-        throw new Error(
-          `"entry.fetch()" was called but the entry has no options. This is probably a bug, report it to pinia-colada with a boiled down example to reproduce it. Thank you!`,
-        )
+        throw diagnostics.PC_R0004({ method: 'fetch' })
       }
 
       entry.asyncStatus.value = 'loading'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -184,21 +184,18 @@ export const setReactiveValue = Object.assign as <T>(value: T, ...args: T[]) => 
  */
 export interface _EmptyObject {}
 
-/**
- * Dev only warning that is only shown once.
- */
-const warnedMessages = new Set<string>()
+const reportedMessages = new Set<string>()
 
 /**
- * Warns only once. This should only be used in dev
+ * Reports only once. This should only be used in dev.
  *
- * @param message - Message to show
- * @param id - Unique id for the message, defaults to the message
+ * @param id - Unique id for the diagnostic
+ * @param report - Diagnostic report to run
  */
-export function warnOnce(message: string, id: string = message) {
-  if (warnedMessages.has(id)) return
-  warnedMessages.add(id)
-  console.warn(`[@pinia/colada]: ${message}`)
+export function reportOnce(id: string, report: () => void) {
+  if (reportedMessages.has(id)) return
+  reportedMessages.add(id)
+  report()
 }
 
 /**


### PR DESCRIPTION
Nostics migration experiment — **Codex CLI with GPT-5.5** run.

## Shape
- 11 core codes (`PC_R0001`–`PC_R0011`) with good param merges (`method`, `composable`)
- **Scope creep**: also migrated the devtools package — 16 extra `PCD_R*` codes in `devtools/src/diagnostics.ts` for internal RPC/JSON-editor assertions, each with a public docs page, plus `nostics` added to devtools deps
- 28 docs pages under `docs/diagnostics/` (thinner format: no example output)
- `warnOnce` → `reportOnce(id, callback)` — the report sits inside a closure, violating the skill's bare-expression strippability rule (moot here since all sites are dev-guarded)

## Review notes
- Kept legacy `[@pinia/colada]`/`[useInfiniteQuery]` prefixes inside `why` texts (redundant with the `[PC_*]` code prefix)
- Config error filed as `PC_R0001` (runtime) instead of a `C` code
- Docs URL scheme diverges: `/diagnostics/<code>` vs `/errors/<code>` in the Claude runs
- Codex only ran focused test suites itself; I ran the full vitest suite + typecheck + `docs:build` afterwards — all pass

Part of a 4-way model comparison of the `nostics-migration` skill (see sibling PRs).