### PR TITLE
feat(cache-persister): allow custom cache serialization

### DIFF
--- a/docs/cookbook/cache-persistence.md
+++ b/docs/cookbook/cache-persistence.md
@@ -56,20 +56,29 @@ PiniaColadaCachePersister({
 
 ## Custom Serialization
 
-The plugin uses `JSON.stringify` and `JSON.parse` by default. Provide custom `serialize` and `deserialize` functions when your query data contains values that need an app-specific codec, such as `Date` instances:
+The plugin stores the cache with `JSON.stringify` and restores it with `JSON.parse`. JSON cannot represent values like `Date`, `Map`, or `Set`, so they come back as plain strings or objects after a reload. The `stringify` and `parse` options swap in a codec that preserves them, like [devalue](https://github.com/sveltejs/devalue), which you can pass as-is:
 
 ```ts
+import { parse, stringify } from 'devalue'
+
 PiniaColadaCachePersister({
-  serialize: (cache) => mySerializer.stringify(cache),
-  deserialize: (stored) => mySerializer.parse(stored),
+  stringify,
+  parse,
 })
 ```
 
-These functions operate on the whole persisted cache object before it is written to storage and after it is read back.
-`PersistedQueryCache` is part of the plugin's public serializer contract and follows
-Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
+`devalue` handles `Date`, `Map`, `Set`, and friends out of the box. For your own classes, register a reducer and the matching reviver:
 
-If serialization, deserialization, or storage fails, the plugin ignores the error and continues with an empty or stale cache.
+```ts
+import * as devalue from 'devalue'
+
+PiniaColadaCachePersister({
+  stringify: (cache) => devalue.stringify(cache, { Money: (v) => v instanceof Money && [v.amount, v.currency] }),
+  parse: (stored) => devalue.parse(stored, { Money: ([amount, currency]) => new Money(amount, currency) }),
+})
+```
+
+Persistence is best-effort: if serializing or restoring the cache throws, the plugin skips that write or read and continues with a stale or empty cache instead of crashing.
 
 ## Custom Storage
 
@@ -113,5 +122,5 @@ main()
 | `storage`     | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async)                        |
 | `filter`      | `UseQueryEntryFilter`           | -                      | Filter which queries to persist                        |
 | `debounce`    | `number`                        | `1000`                 | Debounce time in ms before persisting                  |
-| `serialize`   | `(cache) => string`             | `JSON.stringify`       | Convert the persisted cache object to a string         |
-| `deserialize` | `(stored) => cache`             | `JSON.parse`           | Restore the persisted cache object from a string       |
+| `stringify`   | `(cache) => string`             | `JSON.stringify`       | Convert the persisted cache object to a string         |
+| `parse`       | `(stored) => cache`             | `JSON.parse`           | Restore the persisted cache object from a string       |

--- a/docs/cookbook/cache-persistence.md
+++ b/docs/cookbook/cache-persistence.md
@@ -70,11 +70,11 @@ PiniaColadaCachePersister({
 `devalue` handles `Date`, `Map`, `Set`, and friends out of the box. For your own classes, register a reducer and the matching reviver:
 
 ```ts
-import * as devalue from 'devalue'
+import { parse, stringify } from 'devalue'
 
 PiniaColadaCachePersister({
-  stringify: (cache) => devalue.stringify(cache, { Money: (v) => v instanceof Money && [v.amount, v.currency] }),
-  parse: (stored) => devalue.parse(stored, { Money: ([amount, currency]) => new Money(amount, currency) }),
+  stringify: (cache) => stringify(cache, { Money: (v) => v instanceof Money && [v.amount, v.currency] }),
+  parse: (stored) => parse(stored, { Money: ([amount, currency]) => new Money(amount, currency) }),
 })
 ```
 

--- a/docs/cookbook/cache-persistence.md
+++ b/docs/cookbook/cache-persistence.md
@@ -54,6 +54,23 @@ PiniaColadaCachePersister({
 })
 ```
 
+## Custom Serialization
+
+The plugin uses `JSON.stringify` and `JSON.parse` by default. Provide custom `serialize` and `deserialize` functions when your query data contains values that need an app-specific codec, such as `Date` instances:
+
+```ts
+PiniaColadaCachePersister({
+  serialize: (cache) => mySerializer.stringify(cache),
+  deserialize: (stored) => mySerializer.parse(stored),
+})
+```
+
+These functions operate on the whole persisted cache object before it is written to storage and after it is read back.
+`PersistedQueryCache` is part of the plugin's public serializer contract and follows
+Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
+
+If serialization, deserialization, or storage fails, the plugin ignores the error and continues with an empty or stale cache.
+
 ## Custom Storage
 
 The plugin works with any storage that implements `getItem` and `setItem`. This includes async storage like IndexedDB:
@@ -90,9 +107,11 @@ main()
 
 ## Options
 
-| Option     | Type                            | Default                | Description                           |
-| ---------- | ------------------------------- | ---------------------- | ------------------------------------- |
-| `key`      | `string`                        | `'pinia-colada-cache'` | Storage key used to persist the cache |
-| `storage`  | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async)       |
-| `filter`   | `UseQueryEntryFilter`           | -                      | Filter which queries to persist       |
-| `debounce` | `number`                        | `1000`                 | Debounce time in ms before persisting |
+| Option        | Type                            | Default                | Description                                            |
+| ------------- | ------------------------------- | ---------------------- | ------------------------------------------------------ |
+| `key`         | `string`                        | `'pinia-colada-cache'` | Storage key used to persist the cache                  |
+| `storage`     | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async)                        |
+| `filter`      | `UseQueryEntryFilter`           | -                      | Filter which queries to persist                        |
+| `debounce`    | `number`                        | `1000`                 | Debounce time in ms before persisting                  |
+| `serialize`   | `(cache) => string`             | `JSON.stringify`       | Convert the persisted cache object to a string         |
+| `deserialize` | `(stored) => cache`             | `JSON.parse`           | Restore the persisted cache object from a string       |

--- a/docs/guide/ssr.md
+++ b/docs/guide/ssr.md
@@ -8,7 +8,7 @@ You can check the [source code of the Nuxt module](https://github.com/posva/pini
 
 ## Serialization
 
-If you use [devalue](https://github.com/Rich-Harris/devalue), you can follow their documentation [for custom types](https://github.com/Rich-Harris/devalue#custom-types). It should look something like this:
+If you use [devalue](https://github.com/sveltejs/devalue), you can follow their documentation [for custom types](https://github.com/sveltejs/devalue#custom-types). It should look something like this:
 
 ```ts
 import devalue from 'devalue'

--- a/docs/plugins/official/cache-persister.md
+++ b/docs/plugins/official/cache-persister.md
@@ -22,8 +22,8 @@ app.use(PiniaColada, {
       debounce: 1000,
       // storage: localStorage,
       // filter: { key: ['todos'] },
-      // serialize: JSON.stringify,
-      // deserialize: JSON.parse,
+      // stringify: JSON.stringify,
+      // parse: JSON.parse,
     }),
   ],
 })
@@ -48,23 +48,10 @@ You can only configure the plugin globally, not per query:
 - `storage: Storage` (default: `localStorage`) is the storage to use (must implement `getItem`, `setItem`, and `removeItem`)
 - `debounce: number` (default: `1000`) is the debounce delay in milliseconds before writing to storage
 - `filter: { key: QueryKey[] }` (default: `undefined`) is an optional filter to only persist certain queries (by key)
-- `serialize: (cache) => string` (default: `JSON.stringify`) converts the persisted cache object to a string
-- `deserialize: (stored) => cache` (default: `JSON.parse`) restores the persisted cache object from a string
+- `stringify: (cache) => string` (default: `JSON.stringify`) converts the cache to a string before storing it
+- `parse: (stored) => cache` (default: `JSON.parse`) restores the cache from the stored string
 
-## Custom serialization
-
-Use `serialize` and `deserialize` when persisted query data needs an app-specific codec, such as preserving `Date` instances:
-
-```ts
-PiniaColadaCachePersister({
-  serialize: (cache) => mySerializer.stringify(cache),
-  deserialize: (stored) => mySerializer.parse(stored),
-})
-```
-
-The callbacks operate on the whole persisted cache object.
-`PersistedQueryCache` is part of the plugin's public serializer contract and follows
-Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
+Use `stringify`/`parse` with a codec like [devalue](https://github.com/sveltejs/devalue) to persist `Date`, `Map`, or custom classes. See [Custom Serialization](../../cookbook/cache-persistence.md#custom-serialization) for examples.
 
 ## Notes
 

--- a/docs/plugins/official/cache-persister.md
+++ b/docs/plugins/official/cache-persister.md
@@ -22,6 +22,8 @@ app.use(PiniaColada, {
       debounce: 1000,
       // storage: localStorage,
       // filter: { key: ['todos'] },
+      // serialize: JSON.stringify,
+      // deserialize: JSON.parse,
     }),
   ],
 })
@@ -46,11 +48,29 @@ You can only configure the plugin globally, not per query:
 - `storage: Storage` (default: `localStorage`) is the storage to use (must implement `getItem`, `setItem`, and `removeItem`)
 - `debounce: number` (default: `1000`) is the debounce delay in milliseconds before writing to storage
 - `filter: { key: QueryKey[] }` (default: `undefined`) is an optional filter to only persist certain queries (by key)
+- `serialize: (cache) => string` (default: `JSON.stringify`) converts the persisted cache object to a string
+- `deserialize: (stored) => cache` (default: `JSON.parse`) restores the persisted cache object from a string
+
+## Custom serialization
+
+Use `serialize` and `deserialize` when persisted query data needs an app-specific codec, such as preserving `Date` instances:
+
+```ts
+PiniaColadaCachePersister({
+  serialize: (cache) => mySerializer.stringify(cache),
+  deserialize: (stored) => mySerializer.parse(stored),
+})
+```
+
+The callbacks operate on the whole persisted cache object.
+`PersistedQueryCache` is part of the plugin's public serializer contract and follows
+Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
 
 ## Notes
 
 - Only successful query results are persisted.
 - Garbage collection still applies: if an entry is removed, it will disappear from persisted data too.
+- Serialization, deserialization, and storage failures are ignored because persisted data is treated as a best-effort cache.
 
 ## Links
 

--- a/plugins/cache-persister/README.md
+++ b/plugins/cache-persister/README.md
@@ -27,6 +27,8 @@ app.use(PiniaColada, {
       key: 'pinia-colada-cache', // Storage key
       storage: localStorage, // Storage backend
       debounce: 1000, // Persist delay in ms
+      serialize: JSON.stringify, // Convert cache to a string
+      deserialize: JSON.parse, // Restore cache from a string
     }),
   ],
 })
@@ -51,12 +53,31 @@ useQuery({
 
 ## Options
 
-| Option     | Type                            | Default                | Description                     |
-| ---------- | ------------------------------- | ---------------------- | ------------------------------- |
-| `key`      | `string`                        | `'pinia-colada-cache'` | Storage key                     |
-| `storage`  | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async) |
-| `filter`   | `UseQueryEntryFilter`           | -                      | Filter which queries to persist |
-| `debounce` | `number`                        | `1000`                 | Debounce time in ms             |
+| Option        | Type                            | Default                | Description                        |
+| ------------- | ------------------------------- | ---------------------- | ---------------------------------- |
+| `key`         | `string`                        | `'pinia-colada-cache'` | Storage key                        |
+| `storage`     | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async)    |
+| `filter`      | `UseQueryEntryFilter`           | -                      | Filter which queries to persist    |
+| `debounce`    | `number`                        | `1000`                 | Debounce time in ms                |
+| `serialize`   | `(cache) => string`             | `JSON.stringify`       | Serializes the cache for storage   |
+| `deserialize` | `(stored) => cache`             | `JSON.parse`           | Deserializes the cache from string |
+
+## Custom Serialization
+
+By default, the plugin uses `JSON.stringify` and `JSON.parse`. If your query data contains values that JSON cannot restore, such as `Date` instances, pass your app's serializer instead:
+
+```ts
+PiniaColadaCachePersister({
+  serialize: (cache) => mySerializer.stringify(cache),
+  deserialize: (stored) => mySerializer.parse(stored),
+})
+```
+
+The callbacks receive the whole persisted cache object, not individual query results.
+`PersistedQueryCache` is part of the plugin's public serializer contract and follows
+Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
+
+If serialization, deserialization, or storage fails, the plugin ignores the error and continues with an empty or stale cache.
 
 ## Filtering Queries
 

--- a/plugins/cache-persister/README.md
+++ b/plugins/cache-persister/README.md
@@ -27,8 +27,8 @@ app.use(PiniaColada, {
       key: 'pinia-colada-cache', // Storage key
       storage: localStorage, // Storage backend
       debounce: 1000, // Persist delay in ms
-      serialize: JSON.stringify, // Convert cache to a string
-      deserialize: JSON.parse, // Restore cache from a string
+      stringify: JSON.stringify, // Convert cache to a string
+      parse: JSON.parse, // Restore cache from a string
     }),
   ],
 })
@@ -53,31 +53,29 @@ useQuery({
 
 ## Options
 
-| Option        | Type                            | Default                | Description                        |
-| ------------- | ------------------------------- | ---------------------- | ---------------------------------- |
-| `key`         | `string`                        | `'pinia-colada-cache'` | Storage key                        |
-| `storage`     | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async)    |
-| `filter`      | `UseQueryEntryFilter`           | -                      | Filter which queries to persist    |
-| `debounce`    | `number`                        | `1000`                 | Debounce time in ms                |
-| `serialize`   | `(cache) => string`             | `JSON.stringify`       | Serializes the cache for storage   |
-| `deserialize` | `(stored) => cache`             | `JSON.parse`           | Deserializes the cache from string |
+| Option      | Type                            | Default                | Description                     |
+| ----------- | ------------------------------- | ---------------------- | ------------------------------- |
+| `key`       | `string`                        | `'pinia-colada-cache'` | Storage key                     |
+| `storage`   | `Storage \| PiniaColadaStorage` | `localStorage`         | Storage backend (sync or async) |
+| `filter`    | `UseQueryEntryFilter`           | -                      | Filter which queries to persist |
+| `debounce`  | `number`                        | `1000`                 | Debounce time in ms             |
+| `stringify` | `(cache) => string`             | `JSON.stringify`       | Stringify the cache for storage |
+| `parse`     | `(stored) => cache`             | `JSON.parse`           | Parse the cache from storage    |
 
 ## Custom Serialization
 
-By default, the plugin uses `JSON.stringify` and `JSON.parse`. If your query data contains values that JSON cannot restore, such as `Date` instances, pass your app's serializer instead:
+By default the plugin uses `JSON.stringify`/`JSON.parse`. To persist values JSON cannot restore (`Date`, `Map`, custom classes…), pass a codec like [devalue](https://github.com/sveltejs/devalue):
 
 ```ts
+import { parse, stringify } from 'devalue'
+
 PiniaColadaCachePersister({
-  serialize: (cache) => mySerializer.stringify(cache),
-  deserialize: (stored) => mySerializer.parse(stored),
+  stringify,
+  parse,
 })
 ```
 
-The callbacks receive the whole persisted cache object, not individual query results.
-`PersistedQueryCache` is part of the plugin's public serializer contract and follows
-Pinia Colada's semver guarantees. Custom codecs may need updates on major version changes.
-
-If serialization, deserialization, or storage fails, the plugin ignores the error and continues with an empty or stale cache.
+Persistence is best-effort: if serializing or restoring the cache throws, the plugin skips that write or read instead of crashing.
 
 ## Filtering Queries
 

--- a/plugins/cache-persister/package.json
+++ b/plugins/cache-persister/package.json
@@ -53,6 +53,7 @@
     "@pinia/colada": "workspace:>="
   },
   "devDependencies": {
-    "@pinia/colada": "workspace:^"
+    "@pinia/colada": "workspace:^",
+    "devalue": "^5.6.4"
   }
 }

--- a/plugins/cache-persister/src/cache-persister.spec.ts
+++ b/plugins/cache-persister/src/cache-persister.spec.ts
@@ -5,7 +5,7 @@ import { createPinia } from 'pinia'
 import { PiniaColada, useQuery, useQueryCache } from '@pinia/colada'
 import type { UseQueryOptions } from '@pinia/colada'
 import { PiniaColadaCachePersister, resetCacheReady, isCacheReady } from './cache-persister'
-import type { PiniaColadaStorage } from './cache-persister'
+import type { PersistedQueryCache, PiniaColadaStorage } from './cache-persister'
 
 // Helper to find entry by data value in object format
 function findEntryByData(stored: Record<string, unknown[]>, data: unknown) {
@@ -206,6 +206,43 @@ describe('PiniaColadaCachePersister', () => {
       expect(vi.mocked(storage.setItem).mock.calls.length).toBeGreaterThanOrEqual(2)
     })
 
+    it('uses custom serialize when persisting cache', async () => {
+      const storage = createMockStorage()
+      const date = new Date('2026-06-26T12:00:00.000Z')
+      let serializedCache: PersistedQueryCache | undefined
+      const serialize = vi.fn((cache: PersistedQueryCache) => {
+        serializedCache = cache
+        return 'custom-cache'
+      })
+
+      factory({ key: ['date'], query: async () => date }, { storage, debounce: 0, serialize })
+
+      await flushPromises()
+      vi.advanceTimersByTime(0)
+      await flushPromises()
+
+      expect(serialize).toHaveBeenCalledTimes(1)
+      expect(serializedCache).toBeDefined()
+      expect(getEntryData(serializedCache! as Record<string, unknown[]>, ['date'])).toBe(date)
+      expect(storage.setItem).toHaveBeenCalledWith('pinia-colada-cache', 'custom-cache')
+    })
+
+    it('handles custom serialize errors gracefully', async () => {
+      const storage = createMockStorage()
+      const serialize = vi.fn(() => {
+        throw new Error('Cannot serialize')
+      })
+
+      factory({ key: ['test'], query: async () => 'data' }, { storage, debounce: 0, serialize })
+
+      await flushPromises()
+      vi.advanceTimersByTime(0)
+      await flushPromises()
+
+      expect(serialize).toHaveBeenCalled()
+      expect(storage.setItem).toHaveBeenCalledTimes(0)
+    })
+
     it('persists on setQueryData', async () => {
       const storage = createMockStorage()
       const query = vi.fn(async () => 'initial')
@@ -289,6 +326,45 @@ describe('PiniaColadaCachePersister', () => {
       factory({ key: ['test'], query }, { storage })
 
       await flushPromises()
+      expect(query).toHaveBeenCalled()
+    })
+
+    it('uses custom deserialize when restoring cache', async () => {
+      const storage = createMockStorage()
+      storage.data['pinia-colada-cache'] = 'custom-cache'
+      const date = new Date('2026-06-26T12:00:00.000Z')
+      const deserialize = vi.fn(
+        (): Record<string, [Date, null, number, Record<string, never>]> => ({
+          '["date"]': [date, null, 0, {}],
+        }),
+      )
+
+      factory(
+        { key: ['date'], query: async () => 'fresh', staleTime: 60_000 },
+        { storage, deserialize },
+      )
+
+      await flushPromises()
+
+      expect(deserialize).toHaveBeenCalledWith('custom-cache')
+      const restored = useQueryCache().getQueryData(['date'])
+      expect(restored).toBeInstanceOf(Date)
+      expect((restored as Date).getTime()).toBe(date.getTime())
+    })
+
+    it('handles custom deserialize errors gracefully', async () => {
+      const storage = createMockStorage()
+      storage.data['pinia-colada-cache'] = 'custom-cache'
+      const deserialize = vi.fn(() => {
+        throw new Error('Cannot deserialize')
+      })
+      const query = vi.fn(async () => 'fresh')
+
+      factory({ key: ['test'], query }, { storage, deserialize })
+
+      await flushPromises()
+
+      expect(deserialize).toHaveBeenCalledWith('custom-cache')
       expect(query).toHaveBeenCalled()
     })
 

--- a/plugins/cache-persister/src/cache-persister.spec.ts
+++ b/plugins/cache-persister/src/cache-persister.spec.ts
@@ -2,10 +2,11 @@ import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { defineComponent } from 'vue'
 import { createPinia } from 'pinia'
+import { parse, stringify } from 'devalue'
 import { PiniaColada, useQuery, useQueryCache } from '@pinia/colada'
 import type { UseQueryOptions } from '@pinia/colada'
 import { PiniaColadaCachePersister, resetCacheReady, isCacheReady } from './cache-persister'
-import type { PersistedQueryCache, PiniaColadaStorage } from './cache-persister'
+import type { PiniaColadaStorage } from './cache-persister'
 
 // Helper to find entry by data value in object format
 function findEntryByData(stored: Record<string, unknown[]>, data: unknown) {
@@ -206,41 +207,18 @@ describe('PiniaColadaCachePersister', () => {
       expect(vi.mocked(storage.setItem).mock.calls.length).toBeGreaterThanOrEqual(2)
     })
 
-    it('uses custom serialize when persisting cache', async () => {
+    it('persists the cache through a custom stringify', async () => {
       const storage = createMockStorage()
-      const date = new Date('2026-06-26T12:00:00.000Z')
-      let serializedCache: PersistedQueryCache | undefined
-      const serialize = vi.fn((cache: PersistedQueryCache) => {
-        serializedCache = cache
-        return 'custom-cache'
-      })
+      const stringify = vi.fn(() => 'custom-serialized')
 
-      factory({ key: ['date'], query: async () => date }, { storage, debounce: 0, serialize })
+      factory({ key: ['test'], query: async () => 'data' }, { storage, debounce: 0, stringify })
 
       await flushPromises()
       vi.advanceTimersByTime(0)
       await flushPromises()
 
-      expect(serialize).toHaveBeenCalledTimes(1)
-      expect(serializedCache).toBeDefined()
-      expect(getEntryData(serializedCache! as Record<string, unknown[]>, ['date'])).toBe(date)
-      expect(storage.setItem).toHaveBeenCalledWith('pinia-colada-cache', 'custom-cache')
-    })
-
-    it('handles custom serialize errors gracefully', async () => {
-      const storage = createMockStorage()
-      const serialize = vi.fn(() => {
-        throw new Error('Cannot serialize')
-      })
-
-      factory({ key: ['test'], query: async () => 'data' }, { storage, debounce: 0, serialize })
-
-      await flushPromises()
-      vi.advanceTimersByTime(0)
-      await flushPromises()
-
-      expect(serialize).toHaveBeenCalled()
-      expect(storage.setItem).toHaveBeenCalledTimes(0)
+      expect(stringify).toHaveBeenCalledTimes(1)
+      expect(storage.setItem).toHaveBeenCalledWith('pinia-colada-cache', 'custom-serialized')
     })
 
     it('persists on setQueryData', async () => {
@@ -329,43 +307,51 @@ describe('PiniaColadaCachePersister', () => {
       expect(query).toHaveBeenCalled()
     })
 
-    it('uses custom deserialize when restoring cache', async () => {
+    it('restores non-JSON values through a custom parse', async () => {
       const storage = createMockStorage()
-      storage.data['pinia-colada-cache'] = 'custom-cache'
+      storage.data['pinia-colada-cache'] = 'custom-serialized'
       const date = new Date('2026-06-26T12:00:00.000Z')
-      const deserialize = vi.fn(
+      const parse = vi.fn(
         (): Record<string, [Date, null, number, Record<string, never>]> => ({
           '["date"]': [date, null, 0, {}],
         }),
       )
 
-      factory(
-        { key: ['date'], query: async () => 'fresh', staleTime: 60_000 },
-        { storage, deserialize },
-      )
+      factory({ key: ['date'], query: async () => 'fresh', staleTime: 60_000 }, { storage, parse })
 
       await flushPromises()
 
-      expect(deserialize).toHaveBeenCalledWith('custom-cache')
+      expect(parse).toHaveBeenCalledWith('custom-serialized')
       const restored = useQueryCache().getQueryData(['date'])
       expect(restored).toBeInstanceOf(Date)
       expect((restored as Date).getTime()).toBe(date.getTime())
     })
 
-    it('handles custom deserialize errors gracefully', async () => {
+    it('round-trips Date values end to end with devalue', async () => {
+      // mirrors the `{ stringify, parse }` devalue example from the docs
       const storage = createMockStorage()
-      storage.data['pinia-colada-cache'] = 'custom-cache'
-      const deserialize = vi.fn(() => {
-        throw new Error('Cannot deserialize')
-      })
-      const query = vi.fn(async () => 'fresh')
+      const date = new Date('2026-06-26T12:00:00.000Z')
 
-      factory({ key: ['test'], query }, { storage, deserialize })
+      // persist a query whose data holds a Date that JSON cannot restore
+      const { wrapper } = factory(
+        { key: ['event'], query: async () => ({ at: date }) },
+        { storage, debounce: 0, stringify, parse },
+      )
+      await flushPromises()
+      vi.advanceTimersByTime(0)
+      await flushPromises()
+      wrapper.unmount()
 
+      // restore into a fresh app from the same storage
+      factory(
+        { key: ['event'], query: async () => ({ at: new Date(0) }), staleTime: 60_000 },
+        { storage, stringify, parse },
+      )
       await flushPromises()
 
-      expect(deserialize).toHaveBeenCalledWith('custom-cache')
-      expect(query).toHaveBeenCalled()
+      const restored = useQueryCache().getQueryData(['event']) as { at: Date }
+      expect(restored.at).toBeInstanceOf(Date)
+      expect(restored.at.getTime()).toBe(date.getTime())
     })
 
     it('resolves isCacheReady when no storage is provided (SSR)', async () => {

--- a/plugins/cache-persister/src/cache-persister.ts
+++ b/plugins/cache-persister/src/cache-persister.ts
@@ -15,6 +15,12 @@ import { hydrateQueryCache, _queryEntry_toJSON } from '@pinia/colada'
 type MaybePromise<T> = T | Promise<T>
 
 /**
+ * Public persisted query cache shape passed to custom serializers.
+ * Changes to this shape follow Pinia Colada's semver guarantees.
+ */
+export type PersistedQueryCache = Record<string, _UseQueryEntryNodeValueSerialized>
+
+/**
  * Async storage interface for storage backends that return promises.
  * Compatible with `Storage` type.
  *
@@ -69,6 +75,18 @@ export interface CachePersisterOptions {
    * @default 1000
    */
   debounce?: number
+
+  /**
+   * Serializes the query cache before storing it.
+   * @default JSON.stringify
+   */
+  serialize?: (cache: PersistedQueryCache) => string
+
+  /**
+   * Deserializes the stored query cache before hydrating it.
+   * @default JSON.parse
+   */
+  deserialize?: (stored: string) => PersistedQueryCache
 }
 
 const DEFAULT_OPTIONS = {
@@ -123,6 +141,8 @@ export function PiniaColadaCachePersister(
     storage = typeof localStorage !== 'undefined' ? localStorage : undefined,
     filter,
     debounce = DEFAULT_OPTIONS.debounce,
+    serialize = JSON.stringify,
+    deserialize = JSON.parse,
   } = options
 
   return ({ queryCache }) => {
@@ -130,7 +150,7 @@ export function PiniaColadaCachePersister(
     let pendingPersist = false
 
     // Serialize filtered entries (excluding error entries)
-    function serializeCache(): Record<string, _UseQueryEntryNodeValueSerialized> {
+    function serializeCache(): PersistedQueryCache {
       return Object.fromEntries(
         // TODO: 2028: directly use .map on the iterator
         queryCache
@@ -154,11 +174,16 @@ export function PiniaColadaCachePersister(
       }
 
       throttleTimeout = setTimeout(() => {
-        const serialized = serializeCache()
-        // Handle both sync and async storage errors
-        Promise.resolve(storage.setItem(key, JSON.stringify(serialized))).catch(() => {
-          // Ignore storage errors (quota exceeded, etc.)
-        })
+        try {
+          const serialized = serializeCache()
+          const stored = serialize(serialized)
+          // Handle both sync and async storage errors
+          Promise.resolve(storage.setItem(key, stored)).catch(() => {
+            // Ignore storage errors (quota exceeded, etc.)
+          })
+        } catch {
+          // Ignore serialization and sync storage errors
+        }
 
         throttleTimeout = undefined
         if (pendingPersist) {
@@ -180,7 +205,7 @@ export function PiniaColadaCachePersister(
         // avoid one extra await if storage is sync
         const stored = storedPromise instanceof Promise ? await storedPromise : storedPromise
         if (stored) {
-          const parsed = JSON.parse(stored) as Record<string, _UseQueryEntryNodeValueSerialized>
+          const parsed = deserialize(stored)
           hydrateQueryCache(queryCache, parsed)
         }
       } catch {

--- a/plugins/cache-persister/src/cache-persister.ts
+++ b/plugins/cache-persister/src/cache-persister.ts
@@ -15,8 +15,8 @@ import { hydrateQueryCache, _queryEntry_toJSON } from '@pinia/colada'
 type MaybePromise<T> = T | Promise<T>
 
 /**
- * Public persisted query cache shape passed to custom serializers.
- * Changes to this shape follow Pinia Colada's semver guarantees.
+ * Plain object the query cache is reduced to before being persisted. This is what custom
+ * {@link CachePersisterOptions.stringify} and {@link CachePersisterOptions.parse} receive.
  */
 export type PersistedQueryCache = Record<string, _UseQueryEntryNodeValueSerialized>
 
@@ -77,16 +77,18 @@ export interface CachePersisterOptions {
   debounce?: number
 
   /**
-   * Serializes the query cache before storing it.
+   * Stringifies the query cache before storing it. Defaults to `JSON.stringify`. Pass a codec like
+   * [devalue](https://github.com/sveltejs/devalue) to preserve `Date`, `Map`, custom classes, etc.
    * @default JSON.stringify
    */
-  serialize?: (cache: PersistedQueryCache) => string
+  stringify?: (cache: PersistedQueryCache) => string
 
   /**
-   * Deserializes the stored query cache before hydrating it.
+   * Parses the stored query cache before hydrating it. Must be the counterpart of
+   * {@link CachePersisterOptions.stringify}.
    * @default JSON.parse
    */
-  deserialize?: (stored: string) => PersistedQueryCache
+  parse?: (stored: string) => PersistedQueryCache
 }
 
 const DEFAULT_OPTIONS = {
@@ -141,8 +143,8 @@ export function PiniaColadaCachePersister(
     storage = typeof localStorage !== 'undefined' ? localStorage : undefined,
     filter,
     debounce = DEFAULT_OPTIONS.debounce,
-    serialize = JSON.stringify,
-    deserialize = JSON.parse,
+    stringify = JSON.stringify,
+    parse = JSON.parse,
   } = options
 
   return ({ queryCache }) => {
@@ -175,14 +177,12 @@ export function PiniaColadaCachePersister(
 
       throttleTimeout = setTimeout(() => {
         try {
-          const serialized = serializeCache()
-          const stored = serialize(serialized)
           // Handle both sync and async storage errors
-          Promise.resolve(storage.setItem(key, stored)).catch(() => {
+          Promise.resolve(storage.setItem(key, stringify(serializeCache()))).catch(() => {
             // Ignore storage errors (quota exceeded, etc.)
           })
         } catch {
-          // Ignore serialization and sync storage errors
+          // Ignore serialization errors, the cache is best-effort
         }
 
         throttleTimeout = undefined
@@ -205,8 +205,7 @@ export function PiniaColadaCachePersister(
         // avoid one extra await if storage is sync
         const stored = storedPromise instanceof Promise ? await storedPromise : storedPromise
         if (stored) {
-          const parsed = deserialize(stored)
-          hydrateQueryCache(queryCache, parsed)
+          hydrateQueryCache(queryCache, parse(stored))
         }
       } catch {
         // Ignore parse errors, start fresh

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,6 +315,9 @@ importers:
       '@pinia/colada':
         specifier: workspace:^
         version: link:../..
+      devalue:
+        specifier: ^5.6.4
+        version: 5.6.4
 
   plugins/debug:
     devDependencies:
@@ -7092,6 +7095,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
## Summary

- add `serialize` / `deserialize` options to `@pinia/colada-plugin-cache-persister`
- keep `JSON.stringify` / `JSON.parse` as defaults for backward compatibility
- export `PersistedQueryCache` as the public serializer contract
- document whole-cache custom serialization and best-effort failure behavior
- cover custom Date round-trip and codec failure paths in tests

Closes #610.

## Verification

- `corepack pnpm --filter @pinia/colada-plugin-cache-persister exec vitest run src/cache-persister.spec.ts`
- `corepack pnpm --filter @pinia/colada-plugin-cache-persister build`
- `corepack pnpm test:types`
- `corepack pnpm lint` (0 errors; one pre-existing warning in `src/infinite-query.ts:405`)
- `corepack pnpm run docs:api:build && corepack pnpm exec vitepress build docs`

Note: `corepack pnpm docs:build` failed in my shell because the nested script calls `pnpm` directly and no global `pnpm` binary is installed. Running the equivalent corepack commands above passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cache persister now supports custom `stringify`/`parse` hooks to store and restore non-JSON-friendly values while keeping JSON as the default.
* **Bug Fixes**
  * Serialization/deserialization/storage failures remain best-effort, so cache persistence/restoration won’t crash the app.
* **Documentation**
  * Expanded cookbook and plugin/README docs with configuration examples and guidance for custom codecs; corrected the SSR “devalue” reference link.
* **Tests**
  * Added coverage for custom codec persistence and restoration (e.g., `devalue` with `Date`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->