### PR TITLE
fix(devtools): normalize component resolver path on Windows

### DIFF
--- a/devtools/vite.config.ts
+++ b/devtools/vite.config.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { defineConfig } from 'vite'
+import { defineConfig, normalizePath } from 'vite'
 import Vue from '@vitejs/plugin-vue'
 import VueDevtools from 'vite-plugin-vue-devtools'
 import Dts from 'unplugin-dts/vite'
@@ -104,7 +104,11 @@ export default defineConfig({
           if (UiComponentRe.test(componentName)) {
             return {
               name: `default`,
-              from: resolve(__dirname, `./src/panel/components/${componentName}.ce.vue`),
+              // normalizePath: on Windows resolve() yields backslash paths that
+              // Vite's import-analysis can't resolve as an import specifier.
+              from: normalizePath(
+                resolve(__dirname, `./src/panel/components/${componentName}.ce.vue`),
+              ),
             }
           }
         },


### PR DESCRIPTION
The unplugin-vue-components resolver returned a raw resolve() path, which on Windows produces backslashes (I:\pinia-colada\...). Vite's import-analysis cannot resolve those as import specifiers, causing "Failed to resolve import" for the U* custom-element components. Wrap the path in normalizePath() to emit forward slashes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component loading in the developer tools on Windows by handling file paths more consistently.
  * Reduced import resolution issues that could prevent `.ce.vue` components from being processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->