### PR TITLE
fix(devtools): lazily initialize devtools info of entries

### DIFF
--- a/devtools/src/PiniaColadaDevtools.vue
+++ b/devtools/src/PiniaColadaDevtools.vue
@@ -1,9 +1,14 @@
 <script setup lang="ts">
 import { onBeforeUnmount, shallowRef, useTemplateRef, watch } from 'vue'
 import { useQueryCache, useMutationCache } from '@pinia/colada'
-import { DuplexChannel, DEVTOOLS_INFO_KEY } from '@pinia/colada-devtools/shared'
+import { DuplexChannel } from '@pinia/colada-devtools/shared'
 import type { AppEmits, DevtoolsEmits } from '@pinia/colada-devtools/shared'
-import { createQueryEntryPayload, createMutationEntryPayload } from './pc-devtools-info-plugin'
+import {
+  createQueryEntryPayload,
+  createMutationEntryPayload,
+  ensureQueryDevtoolsInfo,
+  ensureMutationDevtoolsInfo,
+} from './pc-devtools-info-plugin'
 // use dependency free simple useEventListener because this component is used directly in the app
 import { useEventListener } from './use-event-listener'
 
@@ -40,7 +45,7 @@ queryCache.$onAction(({ name, after, onError, args }) => {
 
     // TODO: throttle
     after(() => {
-      entry[DEVTOOLS_INFO_KEY].simulate = null
+      ensureQueryDevtoolsInfo(entry).simulate = null
       transmitter.emit('queries:update', createQueryEntryPayload(entry))
 
       // emit an update when the data becomes stale
@@ -151,15 +156,15 @@ transmitter.on('queries:simulate:loading', (key) => {
   const entry = queryCache.getEntries({ key, exact: true })[0]
   if (entry) {
     entry.asyncStatus.value = 'loading'
-    entry[DEVTOOLS_INFO_KEY].simulate = 'loading'
+    ensureQueryDevtoolsInfo(entry).simulate = 'loading'
     transmitter.emit('queries:update', createQueryEntryPayload(entry))
   }
 })
 transmitter.on('queries:simulate:loading:stop', (key) => {
   const entry = queryCache.getEntries({ key, exact: true })[0]
-  if (entry && entry[DEVTOOLS_INFO_KEY].simulate === 'loading') {
+  if (entry && ensureQueryDevtoolsInfo(entry).simulate === 'loading') {
     entry.asyncStatus.value = 'idle'
-    entry[DEVTOOLS_INFO_KEY].simulate = null
+    ensureQueryDevtoolsInfo(entry).simulate = null
     transmitter.emit('queries:update', createQueryEntryPayload(entry))
   }
 })
@@ -174,21 +179,21 @@ transmitter.on('queries:simulate:error', (key) => {
       error: new Error('Simulated error'),
     })
     // we set after because setting the entry state resets the simulation
-    entry[DEVTOOLS_INFO_KEY].simulate = 'error'
+    ensureQueryDevtoolsInfo(entry).simulate = 'error'
     transmitter.emit('queries:update', createQueryEntryPayload(entry))
   }
 })
 
 transmitter.on('queries:simulate:error:stop', (key) => {
   const entry = queryCache.getEntries({ key, exact: true })[0]
-  if (entry && entry[DEVTOOLS_INFO_KEY].simulate === 'error') {
+  if (entry && ensureQueryDevtoolsInfo(entry).simulate === 'error') {
     queryCache.cancel(entry)
     queryCache.setEntryState(entry, {
       ...entry.state.value,
       status: entry.state.value.data !== undefined ? 'success' : 'pending',
       error: null,
     })
-    entry[DEVTOOLS_INFO_KEY].simulate = null
+    ensureQueryDevtoolsInfo(entry).simulate = null
     transmitter.emit('queries:update', createQueryEntryPayload(entry))
   }
 })
@@ -209,16 +214,16 @@ transmitter.on('mutations:simulate:loading', (id) => {
   const entry = mutationCache.get(id)
   if (entry) {
     entry.asyncStatus.value = 'loading'
-    entry[DEVTOOLS_INFO_KEY].simulate = 'loading'
+    ensureMutationDevtoolsInfo(entry).simulate = 'loading'
     transmitter.emit('mutations:update', createMutationEntryPayload(entry))
   }
 })
 
 transmitter.on('mutations:simulate:loading:stop', (id) => {
   const entry = mutationCache.get(id)
-  if (entry && entry[DEVTOOLS_INFO_KEY].simulate === 'loading') {
+  if (entry && ensureMutationDevtoolsInfo(entry).simulate === 'loading') {
     entry.asyncStatus.value = 'idle'
-    entry[DEVTOOLS_INFO_KEY].simulate = null
+    ensureMutationDevtoolsInfo(entry).simulate = null
     transmitter.emit('mutations:update', createMutationEntryPayload(entry))
   }
 })
@@ -232,14 +237,14 @@ transmitter.on('mutations:simulate:error', (id) => {
       error: new Error('Simulated error'),
     })
     // we set after because setting the entry state resets the simulation
-    entry[DEVTOOLS_INFO_KEY].simulate = 'error'
+    ensureMutationDevtoolsInfo(entry).simulate = 'error'
     transmitter.emit('mutations:update', createMutationEntryPayload(entry))
   }
 })
 
 transmitter.on('mutations:simulate:error:stop', (id) => {
   const entry = mutationCache.get(id)
-  if (entry && entry[DEVTOOLS_INFO_KEY].simulate === 'error') {
+  if (entry && ensureMutationDevtoolsInfo(entry).simulate === 'error') {
     const state = entry.state.value
     mutationCache.setEntryState(
       entry,
@@ -251,7 +256,7 @@ transmitter.on('mutations:simulate:error:stop', (id) => {
           }
         : { data: state.data, status: 'success', error: null },
     )
-    entry[DEVTOOLS_INFO_KEY].simulate = null
+    ensureMutationDevtoolsInfo(entry).simulate = null
     transmitter.emit('mutations:update', createMutationEntryPayload(entry))
   }
 })

--- a/devtools/src/pc-devtools-info-plugin.spec.ts
+++ b/devtools/src/pc-devtools-info-plugin.spec.ts
@@ -1,0 +1,115 @@
+import { enableAutoUnmount, flushPromises, mount } from '@vue/test-utils'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, defineComponent } from 'vue'
+import { createPinia } from 'pinia'
+import { PiniaColada, useMutation, useMutationCache, useQuery, useQueryCache } from '@pinia/colada'
+import { DEVTOOLS_INFO_KEY } from '@pinia/colada-devtools/shared'
+import {
+  addDevtoolsInfo,
+  createMutationEntryPayload,
+  createQueryEntryPayload,
+} from './pc-devtools-info-plugin'
+
+describe('devtools info plugin', () => {
+  enableAutoUnmount(afterEach)
+
+  function factory() {
+    const pinia = createPinia()
+    // create the caches within an app context to avoid inject() warnings
+    createApp({}).use(pinia).use(PiniaColada, {})
+    const queryCache = useQueryCache(pinia)
+    const mutationCache = useMutationCache(pinia)
+
+    return {
+      queryCache,
+      mutationCache,
+      // mimics mounting `<PiniaColadaDevtools />`
+      installDevtools: () => addDevtoolsInfo(queryCache, mutationCache),
+      // mounts a component that uses pinia colada composables
+      mountComponent: (setup: () => unknown) =>
+        mount(
+          defineComponent({
+            template: '<div></div>',
+            setup: () => {
+              setup()
+              return {}
+            },
+          }),
+          { global: { plugins: [pinia, [PiniaColada, {}]] } },
+        ),
+    }
+  }
+
+  it('initializes the info of query entries created with setQueryData', async () => {
+    const { queryCache, installDevtools, mountComponent } = factory()
+    installDevtools()
+
+    // write-through cache: the entry is created by setQueryData, not by a fetch
+    queryCache.setQueryData(['todos'], ['a'])
+    const entry = queryCache.getEntries({ key: ['todos'], exact: true })[0]!
+    expect(entry[DEVTOOLS_INFO_KEY]).toBeDefined()
+
+    // a disabled query observes the entry, then unmounts and untracks it
+    const wrapper = mountComponent(() =>
+      useQuery({ key: ['todos'], query: async () => [], enabled: false }),
+    )
+    await flushPromises()
+    expect(() => wrapper.unmount()).not.toThrow()
+    expect(entry[DEVTOOLS_INFO_KEY].inactiveAt).toBeGreaterThan(0)
+  })
+
+  it('initializes the info of query entries that existed before the devtools', () => {
+    const { queryCache, installDevtools } = factory()
+    queryCache.setQueryData(['todos'], ['a'])
+    installDevtools()
+
+    const entry = queryCache.getEntries({ key: ['todos'], exact: true })[0]!
+    expect(entry[DEVTOOLS_INFO_KEY]).toBeDefined()
+    // entries with data get their history seeded
+    expect(entry[DEVTOOLS_INFO_KEY].history).toHaveLength(1)
+  })
+
+  it('initializes the info of mutation entries created before the devtools', () => {
+    const { installDevtools, mountComponent } = factory()
+
+    // unensured mutation entries are not in the cache yet, so they are
+    // invisible to the devtools installation
+    const wrapper = mountComponent(() => useMutation({ mutation: async () => 'ok' }))
+    installDevtools()
+
+    // triggers untrack on the entry
+    expect(() => wrapper.unmount()).not.toThrow()
+  })
+
+  it('serializes mutation entries created before the devtools', async () => {
+    const { mutationCache, installDevtools, mountComponent } = factory()
+
+    let mutate!: (vars: void) => void
+    mountComponent(() => ({ mutate } = useMutation({ mutation: async () => 'ok' })))
+    installDevtools()
+
+    mutate()
+    await flushPromises()
+
+    const entry = mutationCache.getEntries()[0]!
+    expect(() => createMutationEntryPayload(entry)).not.toThrow()
+    expect(createMutationEntryPayload(entry).active).toBe(true)
+  })
+
+  it('serializes entries even if the devtools were never installed', () => {
+    const { queryCache, mutationCache, mountComponent } = factory()
+
+    queryCache.setQueryData(['todos'], ['a'])
+    const queryEntry = queryCache.getEntries({ key: ['todos'], exact: true })[0]!
+    expect(() => createQueryEntryPayload(queryEntry)).not.toThrow()
+    expect(createQueryEntryPayload(queryEntry).devtools).toBeDefined()
+
+    let mutate!: (vars: void) => void
+    mountComponent(() => ({ mutate } = useMutation({ mutation: async () => 'ok' })))
+    mutate()
+
+    const mutationEntry = mutationCache.getEntries()[0]!
+    expect(() => createMutationEntryPayload(mutationEntry)).not.toThrow()
+    expect(createMutationEntryPayload(mutationEntry).active).toBe(true)
+  })
+})

--- a/devtools/src/pc-devtools-info-plugin.ts
+++ b/devtools/src/pc-devtools-info-plugin.ts
@@ -13,6 +13,39 @@ import type {
 
 const now = () => performance.timeOrigin + performance.now()
 
+/**
+ * Lazily initializes the devtools info of a query entry. Entries can be
+ * created without going through the tracked cache actions (e.g. mutations not
+ * yet ensured, entries created before the devtools are installed), so every
+ * read must go through here instead of accessing the key directly.
+ * https://github.com/posva/pinia-colada/issues/618
+ */
+export function ensureQueryDevtoolsInfo(entry: UseQueryEntry) {
+  return (entry[DEVTOOLS_INFO_KEY] ??= {
+    count: {
+      total: 0,
+      succeed: 0,
+      errored: 0,
+      cancelled: 0,
+    },
+    updatedAt: entry.when > 0 ? entry.when : now(),
+    inactiveAt: 0,
+    simulate: null,
+    history: [],
+  })
+}
+
+/**
+ * Same as {@link ensureQueryDevtoolsInfo} but for mutation entries.
+ */
+export function ensureMutationDevtoolsInfo(entry: UseMutationEntry) {
+  return (entry[DEVTOOLS_INFO_KEY] ??= {
+    updatedAt: entry.when > 0 ? entry.when : now(),
+    inactiveAt: 0,
+    simulate: null,
+  })
+}
+
 const installationMap = new WeakMap<object, boolean>()
 
 export function addDevtoolsInfo(queryCache: QueryCache, mutationCache: MutationCache): void {
@@ -28,22 +61,11 @@ export function addDevtoolsInfo(queryCache: QueryCache, mutationCache: MutationC
 function addDevtoolsQueryInfo(queryCache: QueryCache): void {
   // apply initialization to any existing entries
   for (const entry of queryCache.getEntries()) {
-    entry[DEVTOOLS_INFO_KEY] ??= {
-      count: {
-        total: 0,
-        succeed: 0,
-        errored: 0,
-        cancelled: 0,
-      },
-      updatedAt: entry.when > 0 ? entry.when : now(),
-      inactiveAt: 0,
-      simulate: null,
-      history: [],
-    }
+    const info = ensureQueryDevtoolsInfo(entry)
 
     // add any entry that was added with SSR or without a fetch
-    if (entry.when > 0) {
-      entry[DEVTOOLS_INFO_KEY].history.push({
+    if (entry.when > 0 && !info.history.length) {
+      info.history.push({
         id: 0,
         key: entry.key,
         state: entry.state.value,
@@ -57,26 +79,16 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
   queryCache.$onAction(({ name, args, after, onError }) => {
     if (name === 'create') {
       after((entry) => {
-        entry[DEVTOOLS_INFO_KEY] = {
-          count: {
-            total: 0,
-            succeed: 0,
-            errored: 0,
-            cancelled: 0,
-          },
-          updatedAt: now(),
-          inactiveAt: 0,
-          simulate: null,
-          history: [],
-        }
+        ensureQueryDevtoolsInfo(entry)
       })
     } else if (name === 'fetch') {
       const [entry] = args
-      entry[DEVTOOLS_INFO_KEY].count.total++
-      entry[DEVTOOLS_INFO_KEY].updatedAt = now()
+      const info = ensureQueryDevtoolsInfo(entry)
+      info.count.total++
+      info.updatedAt = now()
       const createdAt = now()
       const historyEntry: UseQueryEntryHistoryEntry = {
-        id: (entry[DEVTOOLS_INFO_KEY].history.at(0)?.id ?? -1) + 1,
+        id: (info.history.at(0)?.id ?? -1) + 1,
         key: entry.key,
         state: entry.state.value,
         updatedAt: createdAt,
@@ -92,16 +104,15 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
         }
       }
 
-      entry[DEVTOOLS_INFO_KEY].history.unshift(historyEntry)
+      info.history.unshift(historyEntry)
       // limit history to 10 entries
-      entry[DEVTOOLS_INFO_KEY].history = entry[DEVTOOLS_INFO_KEY].history.slice(0, 10)
+      info.history = info.history.slice(0, 10)
 
       after(() => {
         if (isEnabled) {
           historyEntry.fetchTime!.end = now()
-          entry[DEVTOOLS_INFO_KEY].count.succeed++
-          // set by the setEntryState
-          // entry[DEVTOOLS_INFO_KEY].updatedAt = now()
+          info.count.succeed++
+          // updatedAt is set by the setEntryState
           historyEntry.state = entry.state.value
           historyEntry.updatedAt = now()
         }
@@ -109,9 +120,8 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
       onError(() => {
         if (isEnabled) {
           historyEntry.fetchTime!.end = now()
-          entry[DEVTOOLS_INFO_KEY].count.errored++
-          // set by the setEntryState
-          // entry[DEVTOOLS_INFO_KEY].updatedAt = now()
+          info.count.errored++
+          // updatedAt is set by the setEntryState
           historyEntry.state = entry.state.value
           historyEntry.updatedAt = now()
         }
@@ -119,14 +129,15 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
     } else if (name === 'cancel') {
       const [entry] = args
       if (entry.pending) {
-        entry[DEVTOOLS_INFO_KEY].count.cancelled++
+        ensureQueryDevtoolsInfo(entry).count.cancelled++
       }
     } else if (name === 'setEntryState') {
       const [entry] = args
-      let lastHistoryEntry = entry[DEVTOOLS_INFO_KEY].history[0]
+      const info = ensureQueryDevtoolsInfo(entry)
+      let lastHistoryEntry = info.history[0]
       after(() => {
-        entry[DEVTOOLS_INFO_KEY].updatedAt = now()
-        lastHistoryEntry ??= entry[DEVTOOLS_INFO_KEY].history[0]
+        info.updatedAt = now()
+        lastHistoryEntry ??= info.history[0]
         if (lastHistoryEntry) {
           lastHistoryEntry.state = entry.state.value
           lastHistoryEntry.updatedAt = now()
@@ -134,14 +145,14 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
         // set inactiveAt for prefetched queries to start GC timing
         // both prefetch methods (setQueryData and refresh) call setEntryState when they complete
         if (!entry.active) {
-          entry[DEVTOOLS_INFO_KEY].inactiveAt = now()
+          info.inactiveAt = now()
         }
       })
     } else if (name === 'untrack') {
       const [entry] = args
       after(() => {
         if (!entry.active) {
-          entry[DEVTOOLS_INFO_KEY].inactiveAt = now()
+          ensureQueryDevtoolsInfo(entry).inactiveAt = now()
         }
       })
     }
@@ -181,7 +192,7 @@ export function createQueryEntryPayload(entry: UseQueryEntry): UseQueryEntryPayl
     ),
     gcTimeout: typeof entry.gcTimeout === 'number' ? (entry.gcTimeout as number) : null,
 
-    devtools: entry[DEVTOOLS_INFO_KEY],
+    devtools: ensureQueryDevtoolsInfo(entry),
     plugins: Object.fromEntries(
       Object.entries(entry.ext).filter(([, v]) => v !== null && typeof v === 'object' && !isRef(v)),
     ),
@@ -191,52 +202,41 @@ export function createQueryEntryPayload(entry: UseQueryEntry): UseQueryEntryPayl
 export function addDevtoolsInfoForMutations(mutationCache: MutationCache): void {
   // apply initialization to any existing entries
   for (const entry of mutationCache.getEntries()) {
-    entry[DEVTOOLS_INFO_KEY] ??= {
-      updatedAt: entry.when > 0 ? entry.when : now(),
-      inactiveAt: 0,
-      simulate: null,
-    }
+    ensureMutationDevtoolsInfo(entry)
   }
 
   mutationCache.$onAction(({ name, args, after }) => {
     if (name === 'create') {
       after((entry) => {
-        entry[DEVTOOLS_INFO_KEY] = {
-          updatedAt: now(),
-          inactiveAt: 0,
-          simulate: null,
-        }
+        ensureMutationDevtoolsInfo(entry)
       })
     } else if (name === 'ensure') {
       // mutations can create entries before the devtools
       // and then get an id assigned later
       // https://github.com/posva/pinia-colada/issues/469
       const [entry] = args
-      entry[DEVTOOLS_INFO_KEY] ??= {
-        updatedAt: now(),
-        inactiveAt: 0,
-        simulate: null,
-      }
+      ensureMutationDevtoolsInfo(entry)
     } else if (name === 'mutate') {
       const [entry] = args
-      entry[DEVTOOLS_INFO_KEY].updatedAt = now()
+      ensureMutationDevtoolsInfo(entry).updatedAt = now()
     } else if (name === 'setEntryState') {
       const [entry] = args
       after(() => {
-        entry[DEVTOOLS_INFO_KEY].updatedAt = now()
+        ensureMutationDevtoolsInfo(entry).updatedAt = now()
       })
     } else if (name === 'untrack') {
       const [entry] = args
       after(() => {
         // differently from queries, mutations are inactive if untracked
         // because they can only be tracked once
-        entry[DEVTOOLS_INFO_KEY].inactiveAt = now()
+        ensureMutationDevtoolsInfo(entry).inactiveAt = now()
       })
     }
   })
 }
 
 export function createMutationEntryPayload(entry: UseMutationEntry): UseMutationEntryPayload {
+  const devtools = ensureMutationDevtoolsInfo(entry)
   return {
     id: entry.id,
     key: entry.key,
@@ -248,7 +248,7 @@ export function createMutationEntryPayload(entry: UseMutationEntry): UseMutation
       gcTime: entry.options.gcTime,
     },
     gcTimeout: typeof entry.gcTimeout === 'number' ? (entry.gcTimeout as number) : null,
-    active: entry[DEVTOOLS_INFO_KEY].inactiveAt === 0,
-    devtools: entry[DEVTOOLS_INFO_KEY],
+    active: devtools.inactiveAt === 0,
+    devtools,
   }
 }

--- a/devtools/src/pc-devtools-info-plugin.ts
+++ b/devtools/src/pc-devtools-info-plugin.ts
@@ -64,7 +64,7 @@ function addDevtoolsQueryInfo(queryCache: QueryCache): void {
     const info = ensureQueryDevtoolsInfo(entry)
 
     // add any entry that was added with SSR or without a fetch
-    if (entry.when > 0 && !info.history.length) {
+    if (entry.when > 0) {
       info.history.push({
         id: 0,
         key: entry.key,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,6 +69,24 @@ export default defineConfig({
           execArgv: ['--expose-gc'],
         },
       },
+      {
+        extends: true,
+        resolve: {
+          alias: {
+            '@pinia/colada-devtools/shared': fileURLToPath(
+              new URL('./devtools/src/shared/index.ts', import.meta.url),
+            ),
+          },
+        },
+        test: {
+          name: {
+            label: '🔍 @pinia/colada-devtools',
+            color: 'yellow',
+          },
+          root: './devtools',
+          include: ['src/**/*.{test,spec}.ts'],
+        },
+      },
       ...pluginsProjects,
       // TODO: once they upgrade to vitest 4
       // './nuxt',


### PR DESCRIPTION
## Summary

Fixes #618

The devtools metadata stored under `DEVTOOLS_INFO_KEY` was only initialized in the `create` action's `after` hook and in the `getEntries()` loop that runs when the devtools install. `useMutation()` creates an id-0 entry that is not stored in the mutation cache until it is ensured, so when a component using `useMutation` mounted before `<PiniaColadaDevtools />`, the install loop couldn't see the entry and unmounting crashed in the `untrack` handler with `TypeError: can't access property "inactiveAt"`. The serializers and other `$onAction` handlers had the same unguarded reads.

## Changes

- Add `ensureQueryDevtoolsInfo()` / `ensureMutationDevtoolsInfo()` lazy-init accessors and route every read of `DEVTOOLS_INFO_KEY` through them (plugin handlers, both entry serializers, and the simulate/untrack handlers in `PiniaColadaDevtools.vue`)
- Add a `@pinia/colada-devtools` vitest project (the devtools package had no test wiring) and unit tests covering the orderings from the issue: entries created via `setQueryData`, entries existing before the devtools install, and mutation entries created before the devtools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved devtools metadata initialization and reliability for query and mutation entries created before devtools is active.
  * Prevented errors when inspecting inactive queries and mutations.
  * Made query/mutation simulation states consistently set and cleared after loading/error simulation stop events.
* **Tests**
  * Added Vitest coverage for query/mutation tracking, devtools payload serialization, history initialization, and inactive entry handling.
* **Chores**
  * Added a dedicated Vitest project configuration for the devtools test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->