### PR TITLE
fix(persister): account for time spent in storage on restore

### DIFF
--- a/plugins/cache-persister/src/cache-persister.spec.ts
+++ b/plugins/cache-persister/src/cache-persister.spec.ts
@@ -251,6 +251,33 @@ describe('PiniaColadaCachePersister', () => {
       expect(useQueryCache().getQueryData(['restored'])).toBe('restored-data')
     })
 
+    it('treats restored entries as stale by the time they spent in storage', async () => {
+      const storage = createMockStorage()
+      const staleTime = 60_000
+      const query = vi.fn(async () => 'cached')
+
+      // session 1: fetch and persist at T0
+      vi.setSystemTime(new Date(2026, 0, 1, 0, 0, 0))
+      const { wrapper: app1 } = factory(
+        { key: ['weekend'], query, staleTime },
+        { storage, debounce: 0 },
+      )
+      await runPersist()
+      expect(query).toHaveBeenCalledTimes(1)
+      app1.unmount()
+
+      // the snapshot sits in storage well past staleTime; only the clock moves
+      vi.setSystemTime(new Date(2026, 0, 4, 0, 0, 0))
+
+      // session 2: restore — the entry is days old, so it must refetch on mount
+      resetCacheReady()
+      factory({ key: ['weekend'], query, staleTime }, { storage })
+      await flushPromises()
+      await flushPromises()
+
+      expect(query).toHaveBeenCalledTimes(2)
+    })
+
     it('isCacheReady resolves after restore', async () => {
       const storage = createMockStorage()
       storage.data['pinia-colada-cache'] = JSON.stringify({

--- a/plugins/cache-persister/src/cache-persister.ts
+++ b/plugins/cache-persister/src/cache-persister.ts
@@ -182,7 +182,17 @@ export function PiniaColadaCachePersister(
               queryCache
                 // we only care about entries with data
                 .getEntries({ ...filter, status: 'success' })
-                .map((entry) => [entry.keyHash, _queryEntry_toJSON(entry)]),
+                .map((entry) => {
+                  const serialized = _queryEntry_toJSON(entry)
+                  // Persist an absolute fetch timestamp. _queryEntry_toJSON stores
+                  // the entry age relative to serialize time, which only holds
+                  // while serialize and hydrate run in the same tick (SSR). For
+                  // long-lived storage the wall-clock time the snapshot spends in
+                  // storage would otherwise be lost and restored entries would be
+                  // treated as fresh no matter how old they are (see restore()).
+                  if (entry.when) serialized[2] = entry.when
+                  return [entry.keyHash, serialized]
+                }),
             ),
           ),
         )
@@ -231,7 +241,22 @@ export function PiniaColadaCachePersister(
         // exist before queries created in the same tick fetch
         const stored = raw instanceof Promise ? await raw : raw
         if (stored) {
-          hydrateQueryCache(queryCache, parse(stored))
+          const serializedCache = parse(stored)
+          // _queryEntry_toJSON stores the entry age relative to serialize time,
+          // which loses the wall-clock time the snapshot spends in storage. We
+          // persist an absolute fetch timestamp instead, so recompute the
+          // relative age hydrateQueryCache expects from the time elapsed since
+          // the snapshot was written. Absolute ms timestamps are >= 1e12 (post
+          // 2001), while snapshots persisted by older versions stored a much
+          // smaller relative age and are hydrated unchanged (backward compatible).
+          for (const keyHash in serializedCache) {
+            const entry = serializedCache[keyHash]
+            const when = entry?.[2]
+            if (typeof when === 'number' && when >= 1e12) {
+              entry[2] = Date.now() - when
+            }
+          }
+          hydrateQueryCache(queryCache, serializedCache)
         }
       } catch (error) {
         // corrupt data, start fresh


### PR DESCRIPTION
## Problem

`@pinia/colada-plugin-cache-persister` serializes each entry's age **relative to serialize time** (`Date.now() - when`, via `_queryEntry_toJSON`). That format is designed for same-tick SSR serialize/hydrate, but for **long-lived storage** (e.g. IndexedDB) the wall-clock time the snapshot spends in storage is lost: `hydrateQueryCache` reconstructs `when = Date.now() - age`, so a snapshot persisted seconds after a fetch is restored as fresh no matter whether it was written a minute or a month ago.

**Impact:** with `staleTime` + persistent storage, a snapshot persisted on Friday and restored on Monday is served as fresh for the full `staleTime` — users see days-old data on app start with no refetch. (#627 reports this from production.)

## Fix

Persist an **absolute** fetch timestamp (`entry.when`) instead of the relative age, and on restore recompute the relative age `hydrateQueryCache` expects from the time elapsed since the snapshot was written (`Date.now() - when`). The relative encoding in core (`_queryEntry_toJSON` / `hydrateQueryCache`) is untouched — the plugin converts to/from absolute at its own boundary.

### Backward compatibility

Snapshots persisted by older versions stored a small relative age. Absolute epoch-ms timestamps are `>= 1e12` (post-2001), so anything smaller is recognized as a legacy relative age and hydrated unchanged — **no behavior change for existing persisted data**. The `-1` "no timestamp" sentinel is also left untouched.

## Testing

Added a regression test that reproduces the issue end to end:
- session 1: fetch + persist at `T0` (fake clock), then unmount;
- advance the system clock well past `staleTime` (simulating time spent in storage);
- session 2: restore from the same storage and assert the entry is now stale, so the query refetches on mount.

Verified **fail-before / pass-after** the change, and the full plugin suite is green (32/32), including the existing `Date`-round-trip-with-devalue and pre-populated-restore tests, which confirm backward compatibility is preserved.

```
 ✓ src/cache-persister.spec.ts (32 tests) 
 Test Files  1 passed (1)
      Tests  32 passed (32)
```

Formatted with `oxfmt`; linted with `oxlint`; `tsgo` type-check clean.

## Alternatives considered

Per the discussion in #627, an alternative is to wrap the persisted payload as `{ persistedAt, entries }` and add the elapsed time on restore. I went with storing the absolute timestamp in the existing entry slot because it needs **no change to the persisted shape or to the `stringify`/`parse` contract** (custom codecs such as `devalue` are unaffected) and no extra storage entry, while still being fully backward compatible. Happy to switch to the wrapped-payload approach if that's preferred.

Closes #627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored persisted cache entries now correctly account for the time elapsed since they were fetched.
  * Stale data is refetched after restoration instead of being treated as fresh.
  * Existing persisted cache snapshots remain compatible with the updated restoration behavior.

* **Tests**
  * Added coverage to verify cache expiration across extended periods between sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->