### PR TITLE
Preserve date during persistence

### DIFF
--- a/docs/cookbook/cache-persistence.md
+++ b/docs/cookbook/cache-persistence.md
@@ -78,6 +78,8 @@ PiniaColadaCachePersister({
 })
 ```
 
+The object handed to `stringify`, and expected back from `parse`, maps each query key hash to a `[data, error, when, meta]` tuple, where `when` is the local time (`Date.now()`) of its last fetch. Because that timestamp is absolute, an entry restored days later is correctly stale and refetches on mount instead of being served as fresh.
+
 Persistence is best-effort: if serializing or restoring the cache throws, the plugin skips that write or read and continues with a stale or empty cache instead of crashing.
 
 ## Custom Storage

--- a/plugins/cache-persister/README.md
+++ b/plugins/cache-persister/README.md
@@ -77,6 +77,8 @@ PiniaColadaCachePersister({
 })
 ```
 
+The object handed to `stringify`, and expected back from `parse`, maps each query key hash to a `[data, error, when, meta]` tuple, where `when` is the local time (`Date.now()`) of its last fetch. Because that timestamp is absolute, an entry restored days later is correctly stale and refetches on mount instead of being served as fresh.
+
 Persistence is best-effort: if serializing or restoring the cache throws, the plugin skips that write or read instead of crashing. Pass `onStringifyError`/`onParseError` to observe those failures.
 
 ## Filtering Queries

--- a/plugins/cache-persister/src/cache-persister.spec.ts
+++ b/plugins/cache-persister/src/cache-persister.spec.ts
@@ -118,6 +118,13 @@ describe('PiniaColadaCachePersister', () => {
     return JSON.parse(storage.data['pinia-colada-cache']!)
   }
 
+  function writeCache(
+    storage: { data: Record<string, string> },
+    entries: Record<string, unknown[]>,
+  ) {
+    storage.data['pinia-colada-cache'] = JSON.stringify(entries)
+  }
+
   describe('persistence', () => {
     it('persists cache to storage after debounce', async () => {
       const storage = createMockStorage()
@@ -237,9 +244,7 @@ describe('PiniaColadaCachePersister', () => {
     it('restores cache from storage on init', async () => {
       const storage = createMockStorage()
       // Pre-populate storage with cached data
-      storage.data['pinia-colada-cache'] = JSON.stringify({
-        '["restored"]': ['restored-data', null, 0, {}],
-      })
+      writeCache(storage, { '["restored"]': ['restored-data', null, Date.now(), {}] })
 
       const query = vi.fn(async () => 'fresh-data')
 
@@ -253,9 +258,7 @@ describe('PiniaColadaCachePersister', () => {
 
     it('isCacheReady resolves after restore', async () => {
       const storage = createMockStorage()
-      storage.data['pinia-colada-cache'] = JSON.stringify({
-        '["test"]': ['cached', null, 0, {}],
-      })
+      writeCache(storage, { '["test"]': ['cached', null, Date.now(), {}] })
 
       let ready = false
       isCacheReady().then(() => {
@@ -288,9 +291,11 @@ describe('PiniaColadaCachePersister', () => {
       const storage = createMockStorage()
       storage.data['pinia-colada-cache'] = 'custom-serialized'
       const date = new Date('2026-06-26T12:00:00.000Z')
-      const parse = vi.fn((): Record<string, [Date, null, number, Record<string, never>]> => ({
-        '["date"]': [date, null, 0, {}],
-      }))
+      const parse = vi.fn(
+        (): Record<string, [Date, null, number, Record<string, never>]> => ({
+          '["date"]': [date, null, Date.now(), {}],
+        }),
+      )
 
       factory({ key: ['date'], query: async () => 'fresh', staleTime: 60_000 }, { storage, parse })
 
@@ -338,6 +343,108 @@ describe('PiniaColadaCachePersister', () => {
 
       await flushPromises()
       expect(ready).toBe(true)
+    })
+  })
+
+  describe('staleness', () => {
+    it('stores an absolute timestamp on each entry', async () => {
+      const storage = createMockStorage()
+
+      factory({ key: ['a'], query: async () => 'a-data' }, { storage, debounce: 0 })
+      await runPersist()
+      const fetchedAt = Date.now()
+
+      // a second query fetches later and must keep its own timestamp
+      vi.setSystemTime(fetchedAt + 5000)
+      useQueryCache().setQueryData(['b'], 'b-data')
+      await runPersist()
+
+      const stored = readCache(storage)
+      expect(stored['["a"]']?.[2]).toBe(fetchedAt)
+      expect(stored['["b"]']?.[2]).toBe(fetchedAt + 5000)
+    })
+
+    it('ages each entry independently on restore', async () => {
+      const storage = createMockStorage()
+      writeCache(storage, {
+        '["old"]': ['old-data', null, Date.now() - 120_000, {}],
+        '["recent"]': ['recent-data', null, Date.now() - 1000, {}],
+      })
+
+      const oldQuery = vi.fn(async () => 'old-fresh')
+      const recentQuery = vi.fn(async () => 'recent-fresh')
+      factory(
+        [
+          { key: ['old'], query: oldQuery, staleTime: 60_000 },
+          { key: ['recent'], query: recentQuery, staleTime: 60_000 },
+        ],
+        { storage },
+      )
+
+      await flushPromises()
+
+      expect(oldQuery).toHaveBeenCalledTimes(1)
+      expect(recentQuery).toHaveBeenCalledTimes(0)
+    })
+
+    it('restores entries as stale after they sat in storage', async () => {
+      const storage = createMockStorage()
+
+      const { wrapper } = factory(
+        { key: ['test'], query: async () => 'persisted', staleTime: 600_000 },
+        { storage, debounce: 0 },
+      )
+      await runPersist()
+      wrapper.unmount()
+
+      // a weekend goes by with the app closed
+      vi.setSystemTime(Date.now() + 3 * 24 * 60 * 60 * 1000)
+
+      resetCacheReady()
+      const query = vi.fn(async () => 'fresh')
+      factory({ key: ['test'], query, staleTime: 600_000 }, { storage })
+      await isCacheReady()
+      await flushPromises()
+
+      // data is still hydrated for an instant first paint but it's stale, so it refetches
+      expect(query).toHaveBeenCalledTimes(1)
+      expect(useQueryCache().getQueryData(['test'])).toBe('fresh')
+    })
+
+    it('keeps restored entries fresh within the stale time', async () => {
+      const storage = createMockStorage()
+
+      const { wrapper } = factory(
+        { key: ['test'], query: async () => 'persisted', staleTime: 600_000 },
+        { storage, debounce: 0 },
+      )
+      await runPersist()
+      wrapper.unmount()
+
+      vi.setSystemTime(Date.now() + 1000)
+
+      resetCacheReady()
+      const query = vi.fn(async () => 'fresh')
+      factory({ key: ['test'], query, staleTime: 600_000 }, { storage })
+      await isCacheReady()
+      await flushPromises()
+
+      expect(query).toHaveBeenCalledTimes(0)
+      expect(useQueryCache().getQueryData(['test'])).toBe('persisted')
+    })
+
+    it('ignores a timestamp in the future', async () => {
+      const storage = createMockStorage()
+      // the device clock went backwards since the entry was persisted
+      writeCache(storage, { '["test"]': ['cached', null, Date.now() + 60_000, {}] })
+
+      const query = vi.fn(async () => 'fresh')
+      factory({ key: ['test'], query, staleTime: 30_000 }, { storage })
+
+      await flushPromises()
+
+      expect(query).toHaveBeenCalledTimes(0)
+      expect(useQueryCache().getQueryData(['test'])).toBe('cached')
     })
   })
 
@@ -420,9 +527,7 @@ describe('PiniaColadaCachePersister', () => {
 
     it('restores from async storage', async () => {
       const storage = createAsyncStorage()
-      storage.data['pinia-colada-cache'] = JSON.stringify({
-        '["async-restored"]': ['async-cached', null, 0, {}],
-      })
+      writeCache(storage, { '["async-restored"]': ['async-cached', null, Date.now(), {}] })
 
       factory(
         { key: ['async-restored'], query: async () => 'fresh', staleTime: 60_000 },
@@ -436,9 +541,7 @@ describe('PiniaColadaCachePersister', () => {
 
     it('calls getItem once when restoring from async storage', async () => {
       const storage = createAsyncStorage()
-      storage.data['pinia-colada-cache'] = JSON.stringify({
-        '["once"]': ['cached', null, 0, {}],
-      })
+      writeCache(storage, { '["once"]': ['cached', null, Date.now(), {}] })
 
       factory({ key: ['once'], query: async () => 'fresh' }, { storage })
 
@@ -449,9 +552,7 @@ describe('PiniaColadaCachePersister', () => {
 
     it('isCacheReady waits for async restore', async () => {
       const storage = createAsyncStorage()
-      storage.data['pinia-colada-cache'] = JSON.stringify({
-        '["wait"]': ['waited', null, 0, {}],
-      })
+      writeCache(storage, { '["wait"]': ['waited', null, Date.now(), {}] })
 
       let ready = false
 

--- a/plugins/cache-persister/src/cache-persister.ts
+++ b/plugins/cache-persister/src/cache-persister.ts
@@ -7,10 +7,11 @@
  */
 import type {
   PiniaColadaPluginContext,
+  QueryCache,
+  UseQueryEntry,
   UseQueryEntryFilter,
   _UseQueryEntryNodeValueSerialized,
 } from '@pinia/colada'
-import { hydrateQueryCache, _queryEntry_toJSON } from '@pinia/colada'
 import { diagnostics } from './diagnostics'
 
 type MaybePromise<T> = T | Promise<T>
@@ -18,8 +19,48 @@ type MaybePromise<T> = T | Promise<T>
 /**
  * Plain object the query cache is reduced to before being persisted. This is what custom
  * {@link CachePersisterOptions.stringify} and {@link CachePersisterOptions.parse} receive.
+ * Entries have the same shape as the SSR ones but hold an absolute `when` timestamp: a persisted
+ * entry is restored long after it was written, when an age would make it look freshly fetched.
  */
 export type PersistedQueryCache = Record<string, _UseQueryEntryNodeValueSerialized>
+
+/**
+ * Serializes an entry for storage. Adapted from `_queryEntry_toJSON()` to store `when` as an
+ * absolute time instead of an age.
+ *
+ * @param entry - entry to serialize
+ */
+const persistedEntry_toJSON = ({
+  state: { value },
+  when,
+  meta,
+}: UseQueryEntry): _UseQueryEntryNodeValueSerialized => [value.data, value.error, when, meta]
+
+/**
+ * Hydrates the query cache with persisted entries. Adapted from `hydrateQueryCache()`, which
+ * expects ages, to turn each entry's absolute `when` back into one at restore time.
+ *
+ * @param queryCache - query cache
+ * @param entries - persisted entries
+ */
+function hydratePersistedCache(queryCache: QueryCache, entries: PersistedQueryCache): void {
+  const now = Date.now()
+  for (const keyHash in entries) {
+    const [data, error, when, meta] = entries[keyHash]!
+    queryCache.caches.set(
+      keyHash,
+      queryCache.create(
+        JSON.parse(keyHash),
+        undefined,
+        data,
+        error,
+        // `create()` takes an age; clamped so a clock going backwards cannot make data fresher
+        when == null ? 0 : Math.max(0, now - when),
+        meta,
+      ),
+    )
+  }
+}
 
 /**
  * Async storage interface for storage backends that return promises.
@@ -182,7 +223,7 @@ export function PiniaColadaCachePersister(
               queryCache
                 // we only care about entries with data
                 .getEntries({ ...filter, status: 'success' })
-                .map((entry) => [entry.keyHash, _queryEntry_toJSON(entry)]),
+                .map((entry) => [entry.keyHash, persistedEntry_toJSON(entry)]),
             ),
           ),
         )
@@ -231,7 +272,7 @@ export function PiniaColadaCachePersister(
         // exist before queries created in the same tick fetch
         const stored = raw instanceof Promise ? await raw : raw
         if (stored) {
-          hydrateQueryCache(queryCache, parse(stored))
+          hydratePersistedCache(queryCache, parse(stored))
         }
       } catch (error) {
         // corrupt data, start fresh

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,7 +112,7 @@ export type {
 } from './entry-filter'
 export {
   queryEntry_toJSON as _queryEntry_toJSON,
-  type UseQueryEntryNodeValueSerializd as _UseQueryEntryNodeValueSerialized,
+  type UseQueryEntryNodeValueSerialized as _UseQueryEntryNodeValueSerialized,
 } from './query-store'
 
 export type {

--- a/src/infinite-query.spec.ts
+++ b/src/infinite-query.spec.ts
@@ -18,7 +18,7 @@ import {
   serializeQueryCache,
   useQueryCache,
 } from './query-store'
-import type { UseQueryEntryNodeValueSerializd } from './query-store'
+import type { UseQueryEntryNodeValueSerialized } from './query-store'
 
 describe('useInfiniteQuery', () => {
   beforeEach(() => {
@@ -1315,7 +1315,9 @@ describe('useInfiniteQuery', () => {
 
   // https://github.com/posva/pinia-colada/issues/486
   describe('hydration', () => {
-    function createPiniawithHydratedCache(caches: Record<string, UseQueryEntryNodeValueSerializd>) {
+    function createPiniawithHydratedCache(
+      caches: Record<string, UseQueryEntryNodeValueSerialized>,
+    ) {
       const pinia = createPinia()
       const app = createApp({})
       app.use(pinia)

--- a/src/query-store.spec.ts
+++ b/src/query-store.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, getActivePinia, setActivePinia } from 'pinia'
-import type { UseQueryEntry, UseQueryEntryNodeValueSerializd } from './query-store'
+import type { UseQueryEntry, UseQueryEntryNodeValueSerialized } from './query-store'
 import { useQueryCache } from './query-store'
 import { USE_QUERY_DEFAULTS } from './query-options'
 import { flushPromises, mount } from '@vue/test-utils'

--- a/src/query-store.ts
+++ b/src/query-store.ts
@@ -195,7 +195,7 @@ export type UseQueryEntryFilter = EntryFilter<UseQueryEntry>
  */
 export const queryEntry_toJSON: <TData, TError>(
   entry: UseQueryEntry<TData, TError>,
-) => UseQueryEntryNodeValueSerializd<TData, TError> = ({ state: { value }, when, meta }) => [
+) => UseQueryEntryNodeValueSerialized<TData, TError> = ({ state: { value }, when, meta }) => [
   value.data,
   value.error,
   // because of time zones, we create a relative time
@@ -951,7 +951,7 @@ export function isQueryCache(cache: unknown): cache is QueryCache {
  *
  * @internal
  */
-export type UseQueryEntryNodeValueSerializd<TData = unknown, TError = unknown> = [
+export type UseQueryEntryNodeValueSerialized<TData = unknown, TError = unknown> = [
   /**
    * The data returned by the query.
    */
@@ -981,7 +981,7 @@ export type UseQueryEntryNodeValueSerializd<TData = unknown, TError = unknown> =
  */
 export function hydrateQueryCache(
   queryCache: QueryCache,
-  serializedCache: Record<string, UseQueryEntryNodeValueSerializd>,
+  serializedCache: Record<string, UseQueryEntryNodeValueSerialized>,
 ) {
   for (const keyHash in serializedCache) {
     queryCache.caches.set(
@@ -1003,7 +1003,7 @@ export function hydrateQueryCache(
  */
 export function serializeQueryCache(
   queryCache: QueryCache,
-): Record<string, UseQueryEntryNodeValueSerializd> {
+): Record<string, UseQueryEntryNodeValueSerialized> {
   return Object.fromEntries(
     // TODO: 2028: directly use .map on the iterator
     [...queryCache.caches.entries()].map(([keyHash, entry]) => [keyHash, queryEntry_toJSON(entry)]),

--- a/src/use-query.spec.ts
+++ b/src/use-query.spec.ts
@@ -10,7 +10,7 @@ import type { PropType } from 'vue'
 import { delay, isSpy, mockConsoleError, mockWarn, promiseWithResolvers } from '@posva/test-utils'
 import { PiniaColada } from './pinia-colada'
 import { hydrateQueryCache, QUERY_STORE_ID, useQueryCache } from './query-store'
-import type { UseQueryEntry, UseQueryEntryNodeValueSerializd } from './query-store'
+import type { UseQueryEntry, UseQueryEntryNodeValueSerialized } from './query-store'
 import { useQuery } from './use-query'
 
 describe('useQuery', () => {
@@ -2220,7 +2220,9 @@ describe('useQuery', () => {
   })
 
   describe('hydration', () => {
-    function createPiniawithHydratedCache(caches: Record<string, UseQueryEntryNodeValueSerializd>) {
+    function createPiniawithHydratedCache(
+      caches: Record<string, UseQueryEntryNodeValueSerialized>,
+    ) {
       const pinia = createPinia()
       const app = createApp({})
       app.use(pinia)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the persisted cache format, including query data, errors, metadata, and last-fetch timestamps.
  * Documented how restored cache entries become stale and refetch after expiration.

* **Bug Fixes**
  * Restored cache entries now track expiration independently and correctly refetch when stale.
  * Improved handling of fresh, stale, and future-dated cache entries during restoration.
  * Corrected the name of an exported serialized query type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->