### PR TITLE
fix: update variables on initial mutation

### DIFF
--- a/src/use-mutation.spec.ts
+++ b/src/use-mutation.spec.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { flushPromises, mount, enableAutoUnmount } from '@vue/test-utils'
 import { createPinia } from 'pinia'
-import { defineComponent, effectScope, createApp, ref, nextTick } from 'vue'
+import { defineComponent, effectScope, createApp, h, ref, nextTick, watch } from 'vue'
 import type { GlobalMountOptions } from '@posva/test-utils'
 import { delay } from '@posva/test-utils'
 import type { UseMutationOptions } from './mutation-options'
@@ -128,6 +128,66 @@ describe('useMutation', () => {
     await flushPromises()
     expect(wrapper.vm.data).toBe(42)
     expect(wrapper.vm.status).toBe('success')
+  })
+
+  it('updates variables on the first mutation call', async () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return { ...useMutation({ mutation: async (n: number) => n * 2 }) }
+        },
+        render() {
+          return h('div', String(this.variables))
+        },
+      }),
+      { global: { plugins: [createPinia(), PiniaColada] } },
+    )
+
+    expect(wrapper.text()).toBe('undefined')
+
+    wrapper.vm.mutate(1)
+    await nextTick()
+
+    expect(wrapper.text()).toBe('1')
+  })
+
+  it('does not over trigger sync watchers on initial load', async () => {
+    const watchIsLoadingSpy = vi.fn()
+    const watchVariablesSpy = vi.fn()
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          const mutation = useMutation({ mutation: async (n: number) => n * 2 })
+
+          watch(mutation.isLoading, watchIsLoadingSpy, { flush: 'sync' })
+
+          watch(mutation.variables, watchVariablesSpy, { flush: 'sync' })
+
+          return { ...mutation }
+        },
+        // Prime the computed like a UI rendering an optimistic update would.
+        render() {
+          return h('div', String(this.variables))
+        },
+      }),
+      { global: { plugins: [createPinia(), PiniaColada] } },
+    )
+
+    const p = wrapper.vm.mutateAsync(1)
+
+    expect(watchIsLoadingSpy).toHaveBeenCalledTimes(1)
+    expect(watchIsLoadingSpy).toHaveBeenCalledWith(true, false, expect.any(Function))
+    expect(watchVariablesSpy).toHaveBeenCalledTimes(1)
+    expect(watchVariablesSpy).toHaveBeenCalledWith(1, undefined, expect.any(Function))
+
+    watchIsLoadingSpy.mockClear()
+    watchVariablesSpy.mockClear()
+
+    await p
+
+    expect(watchIsLoadingSpy).toHaveBeenCalledTimes(1)
+    expect(watchIsLoadingSpy).toHaveBeenCalledWith(false, true, expect.any(Function))
+    expect(watchVariablesSpy).toHaveBeenCalledTimes(0)
   })
 
   describe('hooks', () => {

--- a/src/use-mutation.ts
+++ b/src/use-mutation.ts
@@ -11,6 +11,7 @@ import {
   onUnmounted,
   onScopeDispose,
   toValue,
+  triggerRef,
 } from 'vue'
 import { useMutationCache } from './mutation-store'
 import type { UseMutationEntry, UseMutationEntryExtensions } from './mutation-store'
@@ -215,10 +216,14 @@ export function useMutation<
   const variables = computed(() => entry.value.vars)
 
   async function mutateAsync(vars: TVars): Promise<TData> {
-    return mutationCache.mutate(
+    const mutationPromise = mutationCache.mutate(
       // ensures we reuse the initial empty entry and adapt it or create a new one
       (entry.value = mutationCache.ensure(entry.value, vars)),
     )
+    // ensure the entry is reactive on the initial mutation
+    // https://github.com/posva/pinia-colada/issues/636
+    triggerRef(entry)
+    return mutationPromise
   }
 
   function mutate(vars: NoInfer<TVars>) {


### PR DESCRIPTION
## Summary

- invalidate the shallow mutation entry ref after ensuring an entry
- make `variables` reactive on the initial mutation call
- cover rendered variables and synchronous watcher notifications

Fix #636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mutation state so updated variables are reflected immediately in rendered output after the first mutation.
  * Corrected initial mutation reactivity, preventing watchers from triggering unexpectedly while ensuring loading and variable updates are reported accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->