### PR TITLE
test: extra test for watchers

### DIFF
--- a/src/use-mutation.spec.ts
+++ b/src/use-mutation.spec.ts
@@ -151,7 +151,7 @@ describe('useMutation', () => {
     expect(wrapper.text()).toBe('1')
   })
 
-  it('does not over trigger sync watchers on initial load', async () => {
+  it('does not over trigger sync watchers', async () => {
     const watchIsLoadingSpy = vi.fn()
     const watchVariablesSpy = vi.fn()
     const wrapper = mount(
@@ -188,6 +188,13 @@ describe('useMutation', () => {
     expect(watchIsLoadingSpy).toHaveBeenCalledTimes(1)
     expect(watchIsLoadingSpy).toHaveBeenCalledWith(false, true, expect.any(Function))
     expect(watchVariablesSpy).toHaveBeenCalledTimes(0)
+
+    const secondMutation = wrapper.vm.mutateAsync(2)
+
+    expect(watchVariablesSpy).toHaveBeenCalledTimes(1)
+    expect(watchVariablesSpy).toHaveBeenCalledWith(2, 1, expect.any(Function))
+
+    await secondMutation
   })
 
   describe('hooks', () => {


### PR DESCRIPTION
https://github.com/posva/pinia-colada/pull/637#discussion_r3911948914

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded mutation behavior coverage to verify that repeated asynchronous mutations trigger synchronization watchers once with the correct current and previous values.
  - Renamed the related test to reflect that it covers repeated mutations, not only initial loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->